### PR TITLE
Memory Allocation Improvements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -60,6 +60,9 @@ gradleTokenModId =
 
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName =
+
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName =
 
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
@@ -123,7 +126,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +190,3 @@ curseForgeRelations =
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName =

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.14'
 }
 
 

--- a/src/main/java/net/malisis/core/MalisisCore.java
+++ b/src/main/java/net/malisis/core/MalisisCore.java
@@ -58,7 +58,7 @@ import cpw.mods.fml.relauncher.SideOnly;
         modid = MalisisCore.modid,
         name = MalisisCore.modname,
         version = MalisisCore.version,
-        dependencies = "required-after:gtnhlib@[0.0.10,)")
+        dependencies = "required-after:gtnhlib@[0.2.4,)")
 public class MalisisCore implements IMalisisMod {
 
     /** Mod ID. */

--- a/src/main/java/net/malisis/core/renderer/MalisisRenderer.java
+++ b/src/main/java/net/malisis/core/renderer/MalisisRenderer.java
@@ -112,7 +112,7 @@ public class MalisisRenderer extends TileEntitySpecialRenderer
     /** Current parameters for the shape being rendered. */
     protected RenderParameters rp = new RenderParameters();
     /** Current parameters for the face being rendered. */
-    protected RenderParameters params;
+    protected static RenderParameters params = new RenderParameters();
     /** Base brightness of the block. */
     protected int baseBrightness;
     /** An override texture set by the renderer. */
@@ -676,7 +676,11 @@ public class MalisisRenderer extends TileEntitySpecialRenderer
         if (s == null) return;
 
         shape = s;
-        rp = params != null ? params : new RenderParameters();
+        if (params != null) {
+            rp = params;
+        } else {
+            rp.reset();
+        }
 
         // apply transformations
         s.applyMatrix();
@@ -716,7 +720,7 @@ public class MalisisRenderer extends TileEntitySpecialRenderer
         }
 
         face = f;
-        params = new RenderParameters();
+        params.reset();
         params.merge(rp);
         params.merge(faceParams);
 

--- a/src/main/java/net/malisis/core/renderer/Parameter.java
+++ b/src/main/java/net/malisis/core/renderer/Parameter.java
@@ -23,7 +23,7 @@ public class Parameter<T> {
     /** Default value. */
     private T defaultValue;
 
-    /** Current alue. */
+    /** Current value. */
     private T value;
 
     /**
@@ -57,7 +57,7 @@ public class Parameter<T> {
      * Resets the value to its default.
      */
     public void reset() {
-        value = null;
+        value = defaultValue;
     }
 
     /**

--- a/src/main/java/net/malisis/core/util/Point.java
+++ b/src/main/java/net/malisis/core/util/Point.java
@@ -15,6 +15,7 @@ package net.malisis.core.util;
 
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.Vec3;
+
 import org.joml.Vector3d;
 
 /**

--- a/src/main/java/net/malisis/core/util/Point.java
+++ b/src/main/java/net/malisis/core/util/Point.java
@@ -15,6 +15,7 @@ package net.malisis.core.util;
 
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.Vec3;
+import org.joml.Vector3d;
 
 /**
  *
@@ -43,6 +44,12 @@ public class Point {
         this.x = x;
         this.y = y;
         this.z = z;
+    }
+
+    public Point(Vector3d vector) {
+        this.x = vector.x;
+        this.y = vector.y;
+        this.z = vector.z;
     }
 
     /**

--- a/src/main/java/net/malisis/core/util/Ray.java
+++ b/src/main/java/net/malisis/core/util/Ray.java
@@ -71,7 +71,7 @@ public class Ray {
      * Gets the point at the specified distance into a {@link Vector3d}.
      *
      * @param vector {@link Vector3d} to store the result in
-     * @param t the distance
+     * @param t      the distance
      */
     public void getPointAt(Vector3d vector, double t) {
         if (Double.isNaN(t)) return;
@@ -174,6 +174,10 @@ public class Ray {
     }
 
     private boolean isPointInsideAABB(Vector3d point, AxisAlignedBB aabb) {
-        return point.x >= aabb.minX && point.x <= aabb.maxX && point.y >= aabb.minY && point.y <= aabb.maxY && point.z >= aabb.minZ && point.z <= aabb.maxZ;
+        return point.x >= aabb.minX && point.x <= aabb.maxX
+                && point.y >= aabb.minY
+                && point.y <= aabb.maxY
+                && point.z >= aabb.minZ
+                && point.z <= aabb.maxZ;
     }
 }

--- a/src/main/java/net/malisis/core/util/Ray.java
+++ b/src/main/java/net/malisis/core/util/Ray.java
@@ -21,6 +21,7 @@ import net.minecraft.util.Vec3;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.joml.Vector3d;
 
 /**
  *
@@ -67,14 +68,14 @@ public class Ray {
     }
 
     /**
-     * Gets the {@link Point} at the specified distance.
+     * Gets the point at the specified distance into a {@link Vector3d}.
      *
+     * @param vector {@link Vector3d} to store the result in
      * @param t the distance
-     * @return the point at the distance t
      */
-    public Point getPointAt(double t) {
-        if (Double.isNaN(t)) return null;
-        return new Point(origin.x + t * direction.x, origin.y + t * direction.y, origin.z + t * direction.z);
+    public void getPointAt(Vector3d vector, double t) {
+        if (Double.isNaN(t)) return;
+        vector.set(origin.x + t * direction.x, origin.y + t * direction.y, origin.z + t * direction.z);
     }
 
     /**
@@ -123,23 +124,56 @@ public class Ray {
         double iY = intersectY(aabb.maxY);
         double iz = intersectZ(aabb.minZ);
         double iZ = intersectZ(aabb.maxZ);
-        Point interx = ix >= 0 ? getPointAt(ix) : null;
-        Point interX = iX >= 0 ? getPointAt(iX) : null;
-        Point intery = iy >= 0 ? getPointAt(iy) : null;
-        Point interY = iY >= 0 ? getPointAt(iY) : null;
-        Point interz = iz >= 0 ? getPointAt(iz) : null;
-        Point interZ = iZ >= 0 ? getPointAt(iZ) : null;
 
         List<Pair<ForgeDirection, Point>> list = new ArrayList<>();
-        if (interx != null && interx.isInside(aabb)) list.add(Pair.of(ForgeDirection.WEST, interx));
-        if (interX != null && interX.isInside(aabb)) list.add(Pair.of(ForgeDirection.EAST, interX));
 
-        if (intery != null && intery.isInside(aabb)) list.add(Pair.of(ForgeDirection.DOWN, intery));
-        if (interY != null && interY.isInside(aabb)) list.add(Pair.of(ForgeDirection.UP, interY));
+        Vector3d intersector = new Vector3d();
+        if (ix >= 0) {
+            getPointAt(intersector, ix);
+            if (isPointInsideAABB(intersector, aabb)) {
+                list.add(Pair.of(ForgeDirection.WEST, new Point(intersector)));
+            }
+        }
 
-        if (interz != null && interz.isInside(aabb)) list.add(Pair.of(ForgeDirection.NORTH, interz));
-        if (interZ != null && interZ.isInside(aabb)) list.add(Pair.of(ForgeDirection.SOUTH, interZ));
+        if (iX >= 0) {
+            getPointAt(intersector, iX);
+            if (isPointInsideAABB(intersector, aabb)) {
+                list.add(Pair.of(ForgeDirection.EAST, new Point(intersector)));
+            }
+        }
+
+        if (iy >= 0) {
+            getPointAt(intersector, iy);
+            if (isPointInsideAABB(intersector, aabb)) {
+                list.add(Pair.of(ForgeDirection.DOWN, new Point(intersector)));
+            }
+        }
+
+        if (iY >= 0) {
+            getPointAt(intersector, iY);
+            if (isPointInsideAABB(intersector, aabb)) {
+                list.add(Pair.of(ForgeDirection.UP, new Point(intersector)));
+            }
+        }
+
+        if (iz >= 0) {
+            getPointAt(intersector, iz);
+            if (isPointInsideAABB(intersector, aabb)) {
+                list.add(Pair.of(ForgeDirection.NORTH, new Point(intersector)));
+            }
+        }
+
+        if (iZ >= 0) {
+            getPointAt(intersector, iZ);
+            if (isPointInsideAABB(intersector, aabb)) {
+                list.add(Pair.of(ForgeDirection.SOUTH, new Point(intersector)));
+            }
+        }
 
         return list;
+    }
+
+    private boolean isPointInsideAABB(Vector3d point, AxisAlignedBB aabb) {
+        return point.x >= aabb.minX && point.x <= aabb.maxX && point.y >= aabb.minY && point.y <= aabb.maxY && point.z >= aabb.minZ && point.z <= aabb.maxZ;
     }
 }


### PR DESCRIPTION
This PR contains two fixes.

The first is  to the rendering system which would allocate many new instances of `RenderParameters` and `Parameter` every frame. This adjusts that to use a single static instance, and resetting it to a default state every frame, instead of completely destroying it and allocating a new one every frame.

The second change is to some of the raytrace collision code. It updates it to use a mutable Vector3d from JOML and only conditionally allocate Point instances, so the allocation is still there when there is an actual successful ray trace, but before many Point instances were allocated just to figure out the AABB intersection so they were basically always allocated if there was a door, fence gate, or trapdoor anywhere nearby.