### PR TITLE
Drastically reduce memory allocations from custom doors

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,4 +3,5 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok:1.18.24'
 
     implementation 'com.github.GTNewHorizons:GTNHLib:0.2.4:dev'
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:1.0.0-alpha33:dev')
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,5 +3,4 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok:1.18.24'
 
     implementation 'com.github.GTNewHorizons:GTNHLib:0.2.4:dev'
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:1.0.0-alpha33:dev')
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # ExampleMod tag to use as Blowdryer (Spotless, etc.) settings version, leave empty to disable.
 # LOCAL to test local config updates.
-gtnh.settings.blowdryerTag = 0.2.0
+gtnh.settings.blowdryerTag = 0.2.2
 
 # Human-readable mod name, available for mcmod.info population.
 modName = Malisis' Doors
@@ -41,19 +41,19 @@ developmentEnvironmentUserName = Developer
 
 # Enables using modern Java syntax (up to version 17) via Jabel, while still targeting JVM 8.
 # See https://github.com/bsideup/jabel for details on how this works.
-enableModernJavaSyntax = false
+enableModernJavaSyntax = true
 
 # Enables injecting missing generics into the decompiled source code for a better coding experience.
 # Turns most publicly visible List, Map, etc. into proper List<E>, Map<K, V> types.
-enableGenericInjection = false
+enableGenericInjection = true
 
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.
 # If gradleTokenVersion is empty or missing, the field will not be present in the class.
-generateGradleTokenClass =
+generateGradleTokenClass = net.malisis.doors.Tags
 
 # Name of the token containing the project's current version to generate/replace.
-gradleTokenVersion = GRADLETOKEN_VERSION
+gradleTokenVersion = VERSION
 
 # [DEPRECATED] Mod ID replacement token.
 gradleTokenModId =
@@ -70,7 +70,7 @@ gradleTokenGroupName =
 # The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...]).
 # Leave these properties empty to skip individual token replacements.
-replaceGradleTokenInFile = MalisisDoors.java
+replaceGradleTokenInFile =
 
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.

--- a/src/main/java/net/malisis/core/MalisisCommand.java
+++ b/src/main/java/net/malisis/core/MalisisCommand.java
@@ -130,7 +130,8 @@ public class MalisisCommand extends CommandBase {
      * @param params the params
      */
     public void configCommand(ICommandSender sender, String[] params) {
-        if (FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER) {
+        if (FMLCommonHandler.instance()
+            .getEffectiveSide() == Side.SERVER) {
             MalisisCore.log.warn("Can't open configuration GUI on a dedicated server.");
             return;
         }

--- a/src/main/java/net/malisis/core/MalisisCore.java
+++ b/src/main/java/net/malisis/core/MalisisCore.java
@@ -13,6 +13,8 @@
 
 package net.malisis.core;
 
+import static net.malisis.doors.Tags.VERSION;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -27,7 +29,6 @@ import net.malisis.core.util.finiteliquid.FiniteLiquid;
 import net.malisis.core.util.finiteliquid.FiniteLiquidRenderer;
 import net.malisis.core.util.replacement.ReplacementTool;
 import net.malisis.core.util.syncer.Syncer;
-import net.malisis.doors.MalisisDoors;
 import net.minecraft.client.Minecraft;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraft.server.MinecraftServer;
@@ -55,10 +56,10 @@ import cpw.mods.fml.relauncher.SideOnly;
  * The Class MalisisCore.
  */
 @Mod(
-        modid = MalisisCore.modid,
-        name = MalisisCore.modname,
-        version = MalisisCore.version,
-        dependencies = "required-after:gtnhlib@[0.2.4,)")
+    modid = MalisisCore.modid,
+    name = MalisisCore.modname,
+    version = MalisisCore.version,
+    dependencies = "required-after:gtnhlib@[0.2.4,)")
 public class MalisisCore implements IMalisisMod {
 
     /** Mod ID. */
@@ -66,7 +67,7 @@ public class MalisisCore implements IMalisisMod {
     /** Mod name. */
     public static final String modname = "Malisis Core";
     /** Current version. */
-    public static final String version = MalisisDoors.version;
+    public static final String version = VERSION;
     /** Url for the mod. */
     public static final String url = "";
     /** Path for the mod. */
@@ -159,7 +160,8 @@ public class MalisisCore implements IMalisisMod {
         GameRegistry.registerTileEntity(MultiBlockTileEntity.class, "MalisisCoreMultiBlockTileEntity");
 
         MalisisNetwork.createMessages(event.getAsmData());
-        Syncer.get().discover(event.getAsmData());
+        Syncer.get()
+            .discover(event.getAsmData());
     }
 
     /**
@@ -171,8 +173,8 @@ public class MalisisCore implements IMalisisMod {
     public void init(FMLInitializationEvent event) {
         ClientCommandHandler.instance.registerCommand(new MalisisCommand());
 
-        if (FMLCommonHandler.instance().getSide() == Side.CLIENT)
-            new FiniteLiquidRenderer().registerFor(FiniteLiquid.class);
+        if (FMLCommonHandler.instance()
+            .getSide() == Side.CLIENT) new FiniteLiquidRenderer().registerFor(FiniteLiquid.class);
     }
 
     /**
@@ -229,10 +231,12 @@ public class MalisisCore implements IMalisisMod {
         String txt = text.toString();
         if (text instanceof Object[]) txt = Arrays.deepToString((Object[]) text);
         ChatComponentText msg = new ChatComponentText(StatCollector.translateToLocalFormatted(txt, data));
-        if (FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER) {
+        if (FMLCommonHandler.instance()
+            .getEffectiveSide() == Side.SERVER) {
             MinecraftServer server = MinecraftServer.getServer();
 
-            if (server != null) server.getConfigurationManager().sendChatMsg(msg);
+            if (server != null) server.getConfigurationManager()
+                .sendChatMsg(msg);
         } else {
             if (Minecraft.getMinecraft() == null || Minecraft.getMinecraft().thePlayer == null) return;
 

--- a/src/main/java/net/malisis/core/block/MalisisBlock.java
+++ b/src/main/java/net/malisis/core/block/MalisisBlock.java
@@ -77,7 +77,7 @@ public class MalisisBlock extends Block implements IBoundingBox {
 
     @Override
     public void addCollisionBoxesToList(World world, int x, int y, int z, AxisAlignedBB mask, List list,
-            Entity entity) {
+        Entity entity) {
         for (AxisAlignedBB aabb : getBoundingBox(world, x, y, z, BoundingBoxType.COLLISION)) {
             if (aabb != null && mask.intersectsWith(aabb.offset(x, y, z))) list.add(aabb);
         }

--- a/src/main/java/net/malisis/core/client/gui/ClipArea.java
+++ b/src/main/java/net/malisis/core/client/gui/ClipArea.java
@@ -33,12 +33,12 @@ public class ClipArea {
 
     public ClipArea(IClipable container, int clipPadding, boolean intersect) {
         this(
-                container,
-                container.screenX() + clipPadding,
-                container.screenY() + clipPadding,
-                container.screenX() + container.getWidth() - clipPadding,
-                container.screenY() + container.getHeight() - clipPadding,
-                intersect);
+            container,
+            container.screenX() + clipPadding,
+            container.screenY() + clipPadding,
+            container.screenX() + container.getWidth() - clipPadding,
+            container.screenY() + container.getHeight() - clipPadding,
+            intersect);
     }
 
     public ClipArea(IClipable container, int x, int y, int X, int Y, boolean intersect) {

--- a/src/main/java/net/malisis/core/client/gui/GuiRenderer.java
+++ b/src/main/java/net/malisis/core/client/gui/GuiRenderer.java
@@ -184,7 +184,9 @@ public class GuiRenderer extends MalisisRenderer {
     public void bindTexture(GuiTexture texture) {
         if (texture == null || texture == currentTexture) return;
 
-        Minecraft.getMinecraft().getTextureManager().bindTexture(texture.getResourceLocation());
+        Minecraft.getMinecraft()
+            .getTextureManager()
+            .bindTexture(texture.getResourceLocation());
         currentTexture = texture;
     }
 
@@ -258,7 +260,7 @@ public class GuiRenderer extends MalisisRenderer {
     }
 
     public void drawRectangle(float x, float y, float z, float width, float height, int color, int alpha,
-            boolean relative) {
+        boolean relative) {
         if (relative && currentComponent != null) {
             x += currentComponent.screenX();
             y += currentComponent.screenY();
@@ -359,7 +361,7 @@ public class GuiRenderer extends MalisisRenderer {
      * @param relative true if the coordinates are relative to current component
      */
     public void drawText(MalisisFont font, String text, float x, float y, float z, FontRenderOptions fro,
-            boolean relative) {
+        boolean relative) {
         if (relative && currentComponent != null) {
             x += currentComponent.screenX();
             y += currentComponent.screenY();
@@ -427,7 +429,7 @@ public class GuiRenderer extends MalisisRenderer {
      * @param relative  if true, coordinates are relative to current component
      */
     public void drawItemStack(ItemStack itemStack, int x, int y, String label, EnumChatFormatting format,
-            boolean relative) {
+        boolean relative) {
         if (itemStack == null) return;
 
         if (relative && currentComponent != null) {
@@ -435,7 +437,8 @@ public class GuiRenderer extends MalisisRenderer {
             y += currentComponent.screenY();
         }
 
-        FontRenderer fontRenderer = itemStack.getItem().getFontRenderer(itemStack);
+        FontRenderer fontRenderer = itemStack.getItem()
+            .getFontRenderer(itemStack);
         if (fontRenderer == null) fontRenderer = Minecraft.getMinecraft().fontRenderer;
 
         if (label == null && (itemStack.stackSize > 1 || format != null)) label = Integer.toString(itemStack.stackSize);
@@ -447,18 +450,20 @@ public class GuiRenderer extends MalisisRenderer {
         GL11.glEnable(GL12.GL_RESCALE_NORMAL);
 
         itemRenderer.renderItemAndEffectIntoGUI(
-                fontRenderer,
-                Minecraft.getMinecraft().getTextureManager(),
-                itemStack,
-                x,
-                y);
+            fontRenderer,
+            Minecraft.getMinecraft()
+                .getTextureManager(),
+            itemStack,
+            x,
+            y);
         itemRenderer.renderItemOverlayIntoGUI(
-                fontRenderer,
-                Minecraft.getMinecraft().getTextureManager(),
-                itemStack,
-                x,
-                y,
-                label);
+            fontRenderer,
+            Minecraft.getMinecraft()
+                .getTextureManager(),
+            itemStack,
+            x,
+            y,
+            label);
 
         RenderHelper.disableStandardItemLighting();
         GL11.glColor4f(1, 1, 1, 1);
@@ -480,12 +485,12 @@ public class GuiRenderer extends MalisisRenderer {
         itemRenderer.zLevel = 100;
         t.startDrawingQuads();
         drawItemStack(
-                itemStack,
-                mouseX - 8,
-                mouseY - 8,
-                null,
-                itemStack.stackSize == 0 ? EnumChatFormatting.YELLOW : null,
-                false);
+            itemStack,
+            mouseX - 8,
+            mouseY - 8,
+            null,
+            itemStack.stackSize == 0 ? EnumChatFormatting.YELLOW : null,
+            false);
         t.draw();
         itemRenderer.zLevel = 0;
     }

--- a/src/main/java/net/malisis/core/client/gui/GuiTexture.java
+++ b/src/main/java/net/malisis/core/client/gui/GuiTexture.java
@@ -75,7 +75,9 @@ public class GuiTexture {
         DynamicTexture dynTex = new DynamicTexture(image);
         width = image.getWidth();
         height = image.getHeight();
-        resourceLocation = Minecraft.getMinecraft().getTextureManager().getDynamicTextureLocation(name, dynTex);
+        resourceLocation = Minecraft.getMinecraft()
+            .getTextureManager()
+            .getDynamicTextureLocation(name, dynTex);
     }
 
     /**
@@ -204,7 +206,9 @@ public class GuiTexture {
     }
 
     public void delete() {
-        Minecraft.getMinecraft().getTextureManager().deleteTexture(resourceLocation);
+        Minecraft.getMinecraft()
+            .getTextureManager()
+            .deleteTexture(resourceLocation);
     }
 
     @Override

--- a/src/main/java/net/malisis/core/client/gui/MalisisGui.java
+++ b/src/main/java/net/malisis/core/client/gui/MalisisGui.java
@@ -134,7 +134,8 @@ public abstract class MalisisGui extends GuiScreen {
             }
         } catch (Exception e) {
             MalisisCore.message(
-                    "A problem occured while constructing " + e.getClass().getSimpleName() + ": " + e.getMessage());
+                "A problem occured while constructing " + e.getClass()
+                    .getSimpleName() + ": " + e.getMessage());
             e.printStackTrace(new PrintStream(new FileOutputStream(FileDescriptor.out)));
         }
 
@@ -326,7 +327,9 @@ public abstract class MalisisGui extends GuiScreen {
                 component.onScrollWheel(mouseX, mouseY, delta);
             }
         } catch (Exception e) {
-            MalisisCore.message("A problem occured : " + e.getClass().getSimpleName() + ": " + e.getMessage());
+            MalisisCore.message(
+                "A problem occured : " + e.getClass()
+                    .getSimpleName() + ": " + e.getMessage());
             e.printStackTrace(new PrintStream(new FileOutputStream(FileDescriptor.out)));
         }
     }
@@ -359,7 +362,9 @@ public abstract class MalisisGui extends GuiScreen {
             lastClickTime = time;
             lastClickButton = button;
         } catch (Exception e) {
-            MalisisCore.message("A problem occured : " + e.getClass().getSimpleName() + ": " + e.getMessage());
+            MalisisCore.message(
+                "A problem occured : " + e.getClass()
+                    .getSimpleName() + ": " + e.getMessage());
             e.printStackTrace(new PrintStream(new FileOutputStream(FileDescriptor.out)));
         }
     }
@@ -373,7 +378,9 @@ public abstract class MalisisGui extends GuiScreen {
             if (focusedComponent != null)
                 focusedComponent.onDrag(lastMouseX, lastMouseY, x, y, MouseButton.getButton(button));
         } catch (Exception e) {
-            MalisisCore.message("A problem occured : " + e.getClass().getSimpleName() + ": " + e.getMessage());
+            MalisisCore.message(
+                "A problem occured : " + e.getClass()
+                    .getSimpleName() + ": " + e.getMessage());
             e.printStackTrace(new PrintStream(new FileOutputStream(FileDescriptor.out)));
         }
     }
@@ -406,7 +413,9 @@ public abstract class MalisisGui extends GuiScreen {
                 }
             }
         } catch (Exception e) {
-            MalisisCore.message("A problem occured : " + e.getClass().getSimpleName() + ": " + e.getMessage());
+            MalisisCore.message(
+                "A problem occured : " + e.getClass()
+                    .getSimpleName() + ": " + e.getMessage());
             e.printStackTrace(new PrintStream(new FileOutputStream(FileDescriptor.out)));
         }
     }
@@ -423,12 +432,10 @@ public abstract class MalisisGui extends GuiScreen {
             if (ret) return;
 
             if (focusedComponent != null && !keyListeners.contains(focusedComponent)
-                    && focusedComponent.onKeyTyped(keyChar, keyCode))
-                return;
+                && focusedComponent.onKeyTyped(keyChar, keyCode)) return;
 
             if (hoveredComponent != null && !keyListeners.contains(hoveredComponent)
-                    && hoveredComponent.onKeyTyped(keyChar, keyCode))
-                return;
+                && hoveredComponent.onKeyTyped(keyChar, keyCode)) return;
 
             if (isGuiCloseKey(keyCode) && !isOverlay) close();
 
@@ -442,9 +449,8 @@ public abstract class MalisisGui extends GuiScreen {
             }
         } catch (Exception e) {
             MalisisCore.message(
-                    "A problem occured while handling key typed for " + e.getClass().getSimpleName()
-                            + ": "
-                            + e.getMessage());
+                "A problem occured while handling key typed for " + e.getClass()
+                    .getSimpleName() + ": " + e.getMessage());
             e.printStackTrace(new PrintStream(new FileOutputStream(FileDescriptor.out)));
         }
     }
@@ -551,7 +557,8 @@ public abstract class MalisisGui extends GuiScreen {
         if (!doConstruct()) return;
 
         MalisisGui.cancelClose = cancelClose;
-        Minecraft.getMinecraft().displayGuiScreen(this);
+        Minecraft.getMinecraft()
+            .displayGuiScreen(this);
     }
 
     /**
@@ -575,13 +582,17 @@ public abstract class MalisisGui extends GuiScreen {
         if (!doConstruct()) return;
 
         MinecraftForge.EVENT_BUS.register(this);
-        FMLCommonHandler.instance().bus().register(this);
+        FMLCommonHandler.instance()
+            .bus()
+            .register(this);
     }
 
     public void closeOverlay() {
         if (mc.currentScreen == this) close();
         MinecraftForge.EVENT_BUS.unregister(this);
-        FMLCommonHandler.instance().bus().unregister(this);
+        FMLCommonHandler.instance()
+            .bus()
+            .unregister(this);
         onGuiClosed();
     }
 
@@ -720,13 +731,14 @@ public abstract class MalisisGui extends GuiScreen {
     }
 
     public static void playSound(String name, float level) {
-        Minecraft.getMinecraft().getSoundHandler()
-                .playSound(PositionedSoundRecord.func_147674_a(new ResourceLocation(name), level));
+        Minecraft.getMinecraft()
+            .getSoundHandler()
+            .playSound(PositionedSoundRecord.func_147674_a(new ResourceLocation(name), level));
     }
 
     public static boolean isGuiCloseKey(int keyCode) {
         MalisisGui gui = currentGui();
         return keyCode == Keyboard.KEY_ESCAPE || (gui != null && gui.inventoryContainer != null
-                && keyCode == gui.mc.gameSettings.keyBindInventory.getKeyCode());
+            && keyCode == gui.mc.gameSettings.keyBindInventory.getKeyCode());
     }
 }

--- a/src/main/java/net/malisis/core/client/gui/component/UIComponent.java
+++ b/src/main/java/net/malisis/core/client/gui/component/UIComponent.java
@@ -54,7 +54,7 @@ import com.google.common.eventbus.EventBus;
  * @param <T> the type of <code>UIComponent</code>
  */
 public abstract class UIComponent<T extends UIComponent>
-        implements ITransformable.Position<T>, ITransformable.Size<T>, ITransformable.Alpha, IKeyListener {
+    implements ITransformable.Position<T>, ITransformable.Size<T>, ITransformable.Alpha, IKeyListener {
 
     /** The Exception handler for all Component events. */
     private static final ComponentExceptionHandler exceptionHandler = new ComponentExceptionHandler();
@@ -923,23 +923,24 @@ public abstract class UIComponent<T extends UIComponent>
      * @return the property string
      */
     public String getPropertyString() {
-        return "P=" + (parent != null ? parent.getClass().getSimpleName() : "null")
-                + " | "
-                + width
-                + "x"
-                + height
-                + "@"
-                + x
-                + ","
-                + y
-                + " | C="
-                + parentX()
-                + ","
-                + parentY()
-                + " | S="
-                + screenX()
-                + ","
-                + screenY();
+        return "P=" + (parent != null ? parent.getClass()
+            .getSimpleName() : "null")
+            + " | "
+            + width
+            + "x"
+            + height
+            + "@"
+            + x
+            + ","
+            + y
+            + " | C="
+            + parentX()
+            + ","
+            + parentY()
+            + " | S="
+            + screenX()
+            + ","
+            + screenY();
     }
 
     /**

--- a/src/main/java/net/malisis/core/client/gui/component/UISlot.java
+++ b/src/main/java/net/malisis/core/client/gui/component/UISlot.java
@@ -69,9 +69,12 @@ public class UISlot extends UIComponent<UISlot> {
 
         shape = new SimpleGuiShape();
 
-        icon = gui.getGuiTexture().getIcon(209, 30, 18, 18);
-        iconLeft = gui.getGuiTexture().getIcon(209, 30, 1, 18);
-        iconTop = gui.getGuiTexture().getIcon(209, 30, 18, 1);
+        icon = gui.getGuiTexture()
+            .getIcon(209, 30, 18, 18);
+        iconLeft = gui.getGuiTexture()
+            .getIcon(209, 30, 1, 18);
+        iconTop = gui.getGuiTexture()
+            .getIcon(209, 30, 18, 1);
     }
 
     /**
@@ -100,11 +103,13 @@ public class UISlot extends UIComponent<UISlot> {
             return;
         }
 
-        List<String> lines = slot.getItemStack().getTooltip(
-                Minecraft.getMinecraft().thePlayer,
-                Minecraft.getMinecraft().gameSettings.advancedItemTooltips);
+        List<String> lines = slot.getItemStack()
+            .getTooltip(Minecraft.getMinecraft().thePlayer, Minecraft.getMinecraft().gameSettings.advancedItemTooltips);
 
-        lines.set(0, slot.getItemStack().getRarity().rarityColor + lines.get(0));
+        lines.set(
+            0,
+            slot.getItemStack()
+                .getRarity().rarityColor + lines.get(0));
         for (int i = 1; i < lines.size(); i++) lines.set(i, EnumChatFormatting.GRAY + lines.get(i));
 
         tooltip = new UITooltip(getGui()).setText(lines);
@@ -121,10 +126,12 @@ public class UISlot extends UIComponent<UISlot> {
 
     @Override
     public void drawForeground(GuiRenderer renderer, int mouseX, int mouseY, float partialTick) {
-        MalisisInventoryContainer container = MalisisGui.currentGui().getInventoryContainer();
+        MalisisInventoryContainer container = MalisisGui.currentGui()
+            .getInventoryContainer();
         if (container == null) return;
 
-        ItemStack itemStack = slot.getItemStack() != null ? slot.getItemStack().copy() : null;
+        ItemStack itemStack = slot.getItemStack() != null ? slot.getItemStack()
+            .copy() : null;
         ItemStack draggedItemStack = slot.getDraggedItemStack();
 
         // if dragged slots contains an itemStack for this slot, add the stack size
@@ -188,7 +195,8 @@ public class UISlot extends UIComponent<UISlot> {
     @Override
     public boolean onButtonPress(int x, int y, MouseButton button) {
         ActionType action = null;
-        MalisisInventoryContainer container = MalisisGui.currentGui().getInventoryContainer();
+        MalisisInventoryContainer container = MalisisGui.currentGui()
+            .getInventoryContainer();
 
         if (container.getPickedItemStack() != null) return super.onButtonPress(x, y, button);
 
@@ -209,7 +217,8 @@ public class UISlot extends UIComponent<UISlot> {
     @Override
     public boolean onButtonRelease(int x, int y, MouseButton button) {
         ActionType action = null;
-        MalisisInventoryContainer container = MalisisGui.currentGui().getInventoryContainer();
+        MalisisInventoryContainer container = MalisisGui.currentGui()
+            .getInventoryContainer();
 
         if (container.getPickedItemStack() == null || !buttonRelased) {
             buttonRelased = true;
@@ -228,7 +237,8 @@ public class UISlot extends UIComponent<UISlot> {
 
     @Override
     public boolean onDrag(int lastX, int lastY, int x, int y, MouseButton button) {
-        MalisisInventoryContainer container = MalisisGui.currentGui().getInventoryContainer();
+        MalisisInventoryContainer container = MalisisGui.currentGui()
+            .getInventoryContainer();
         ActionType action = null;
 
         if (container.getPickedItemStack() != null && !container.isDraggingItemStack() && buttonRelased) {
@@ -247,7 +257,7 @@ public class UISlot extends UIComponent<UISlot> {
         if (button != MouseButton.LEFT) return super.onDoubleClick(x, y, button);
 
         ActionType action = GuiScreen.isShiftKeyDown() ? ActionType.DOUBLE_SHIFT_LEFT_CLICK
-                : ActionType.DOUBLE_LEFT_CLICK;
+            : ActionType.DOUBLE_LEFT_CLICK;
         MalisisGui.sendAction(action, slot, button.getCode());
         buttonRelased = false;
         return true;
@@ -284,7 +294,9 @@ public class UISlot extends UIComponent<UISlot> {
     public void onHovered(HoveredStateChange<UISlot> event) {
         updateTooltip();
 
-        if (event.getState() && MalisisGui.currentGui().getInventoryContainer().isDraggingItemStack()) {
+        if (event.getState() && MalisisGui.currentGui()
+            .getInventoryContainer()
+            .isDraggingItemStack()) {
             // if (MalisisGui.currentGui().getInventoryContainer().getDraggedItemstack(slot) == null)
             MalisisGui.sendAction(ActionType.DRAG_ADD_SLOT, slot, 0);
         }

--- a/src/main/java/net/malisis/core/client/gui/component/container/UIBackgroundContainer.java
+++ b/src/main/java/net/malisis/core/client/gui/component/container/UIBackgroundContainer.java
@@ -360,10 +360,22 @@ public class UIBackgroundContainer extends UIContainer<UIBackgroundContainer> im
         renderer.enableBlending();
         rp.usePerVertexColor.set(true);
         rp.usePerVertexAlpha.set(true);
-        shape.getVertexes("TopLeft").get(0).setColor(topLeftColor).setAlpha(topLeftAlpha);
-        shape.getVertexes("TopRight").get(0).setColor(topRightColor).setAlpha(topRightAlpha);
-        shape.getVertexes("BottomLeft").get(0).setColor(bottomLeftColor).setAlpha(bottomLeftAlpha);
-        shape.getVertexes("BottomRight").get(0).setColor(bottomRightColor).setAlpha(bottomRightAlpha);
+        shape.getVertexes("TopLeft")
+            .get(0)
+            .setColor(topLeftColor)
+            .setAlpha(topLeftAlpha);
+        shape.getVertexes("TopRight")
+            .get(0)
+            .setColor(topRightColor)
+            .setAlpha(topRightAlpha);
+        shape.getVertexes("BottomLeft")
+            .get(0)
+            .setColor(bottomLeftColor)
+            .setAlpha(bottomLeftAlpha);
+        shape.getVertexes("BottomRight")
+            .get(0)
+            .setColor(bottomRightColor)
+            .setAlpha(bottomRightAlpha);
 
         renderer.disableTextures();
 

--- a/src/main/java/net/malisis/core/client/gui/component/container/UIListContainer.java
+++ b/src/main/java/net/malisis/core/client/gui/component/container/UIListContainer.java
@@ -31,7 +31,7 @@ import net.minecraft.client.gui.GuiScreen;
  *
  */
 public abstract class UIListContainer<T extends UIListContainer, S> extends UIComponent<T>
-        implements IScrollable, IClipable {
+    implements IScrollable, IClipable {
 
     protected int elementSpacing = 0;
     protected boolean unselect = true;
@@ -249,10 +249,10 @@ public abstract class UIListContainer<T extends UIListContainer, S> extends UICo
     public abstract int getElementHeight(S element);
 
     public abstract void drawElementBackground(GuiRenderer renderer, int mouseX, int mouseY, float partialTick,
-            S element, boolean isHovered);
+        S element, boolean isHovered);
 
     public abstract void drawElementForeground(GuiRenderer renderer, int mouseX, int mouseY, float partialTick,
-            S element, boolean isHovered);
+        S element, boolean isHovered);
 
     /**
      * Event fired when a {@link UIListContainer} changes its selected element.<br>

--- a/src/main/java/net/malisis/core/client/gui/component/container/UIPanel.java
+++ b/src/main/java/net/malisis/core/client/gui/component/container/UIPanel.java
@@ -29,7 +29,8 @@ public class UIPanel extends UIContainer<UIPanel> implements ITransformable.Colo
         setPadding(3, 3);
 
         shape = new XYResizableGuiShape(5);
-        icon = gui.getGuiTexture().getXYResizableIcon(200, 15, 15, 15, 5);
+        icon = gui.getGuiTexture()
+            .getXYResizableIcon(200, 15, 15, 15, 5);
     }
 
     public UIPanel(MalisisGui gui, int width, int height) {

--- a/src/main/java/net/malisis/core/client/gui/component/container/UIWindow.java
+++ b/src/main/java/net/malisis/core/client/gui/component/container/UIWindow.java
@@ -34,7 +34,8 @@ public class UIWindow extends UIContainer<UIWindow> implements ICloseable {
         this.anchor = anchor;
 
         shape = new XYResizableGuiShape();
-        icon = gui.getGuiTexture().getXYResizableIcon(200, 0, 15, 15, 5);
+        icon = gui.getGuiTexture()
+            .getXYResizableIcon(200, 0, 15, 15, 5);
     }
 
     public UIWindow(MalisisGui gui, String title, int width, int height) {

--- a/src/main/java/net/malisis/core/client/gui/component/control/UICloseHandle.java
+++ b/src/main/java/net/malisis/core/client/gui/component/control/UICloseHandle.java
@@ -41,7 +41,8 @@ public class UICloseHandle extends UIComponent<UICloseHandle> implements IContro
 
         parent.addControlComponent(this);
 
-        icon = gui.getGuiTexture().getIcon(268, 30, 15, 15);
+        icon = gui.getGuiTexture()
+            .getIcon(268, 30, 15, 15);
     }
 
     @Override

--- a/src/main/java/net/malisis/core/client/gui/component/control/UIMoveHandle.java
+++ b/src/main/java/net/malisis/core/client/gui/component/control/UIMoveHandle.java
@@ -51,7 +51,8 @@ public class UIMoveHandle extends UIComponent<UIMoveHandle> implements IControlC
 
         parent.addControlComponent(this);
 
-        icon = gui.getGuiTexture().getIcon(268, 15, 15, 15);
+        icon = gui.getGuiTexture()
+            .getIcon(268, 15, 15, 15);
     }
 
     public UIMoveHandle(MalisisGui gui, UIComponent parent) {

--- a/src/main/java/net/malisis/core/client/gui/component/control/UIResizeHandle.java
+++ b/src/main/java/net/malisis/core/client/gui/component/control/UIResizeHandle.java
@@ -51,7 +51,8 @@ public class UIResizeHandle extends UIComponent<UIResizeHandle> implements ICont
 
         parent.addControlComponent(this);
 
-        icon = gui.getGuiTexture().getIcon(268, 0, 15, 15);
+        icon = gui.getGuiTexture()
+            .getIcon(268, 0, 15, 15);
     }
 
     public UIResizeHandle(MalisisGui gui, UIComponent parent) {

--- a/src/main/java/net/malisis/core/client/gui/component/control/UIScrollBar.java
+++ b/src/main/java/net/malisis/core/client/gui/component/control/UIScrollBar.java
@@ -127,13 +127,19 @@ public class UIScrollBar extends UIComponent<UIScrollBar> implements IControlCom
         scrollShape.setSize(w, h);
         scrollShape.storeState();
 
-        icon = gui.getGuiTexture().getXYResizableIcon(215, 0, 15, 15, 1);
-        disabledIcon = gui.getGuiTexture().getXYResizableIcon(215, 15, 15, 15, 1);
+        icon = gui.getGuiTexture()
+            .getXYResizableIcon(215, 0, 15, 15, 1);
+        disabledIcon = gui.getGuiTexture()
+            .getXYResizableIcon(215, 15, 15, 15, 1);
 
-        verticalIcon = gui.getGuiTexture().getIcon(230, 0, 8, 15);
-        verticalDisabledIcon = gui.getGuiTexture().getIcon(238, 0, 8, 15);
-        horizontalIcon = gui.getGuiTexture().getIcon(230, 15, 15, 8);
-        horizontalDisabledIcon = gui.getGuiTexture().getIcon(230, 23, 15, 8);
+        verticalIcon = gui.getGuiTexture()
+            .getIcon(230, 0, 8, 15);
+        verticalDisabledIcon = gui.getGuiTexture()
+            .getIcon(238, 0, 8, 15);
+        horizontalIcon = gui.getGuiTexture()
+            .getIcon(230, 15, 15, 8);
+        horizontalDisabledIcon = gui.getGuiTexture()
+            .getIcon(230, 23, 15, 8);
     }
 
     /**
@@ -184,13 +190,13 @@ public class UIScrollBar extends UIComponent<UIScrollBar> implements IControlCom
     @Override
     public int getWidth() {
         return isHorizontal() ? getParent().getWidth() - (hasVisibleOtherScrollbar() ? scrollThickness : 0)
-                : scrollThickness;
+            : scrollThickness;
     }
 
     @Override
     public int getHeight() {
         return isHorizontal() ? scrollThickness
-                : getParent().getHeight() - (hasVisibleOtherScrollbar() ? scrollThickness : 0);
+            : getParent().getHeight() - (hasVisibleOtherScrollbar() ? scrollThickness : 0);
     }
 
     /**
@@ -353,11 +359,11 @@ public class UIScrollBar extends UIComponent<UIScrollBar> implements IControlCom
     @Override
     public String getPropertyString() {
         return type + " | O="
-                + getOffset()
-                + "("
-                + getScrollable().getContentHeight()
-                + ") | "
-                + super.getPropertyString();
+            + getOffset()
+            + "("
+            + getScrollable().getContentHeight()
+            + ") | "
+            + super.getPropertyString();
     }
 
     /**

--- a/src/main/java/net/malisis/core/client/gui/component/control/UISlimScrollbar.java
+++ b/src/main/java/net/malisis/core/client/gui/component/control/UISlimScrollbar.java
@@ -139,6 +139,8 @@ public class UISlimScrollbar extends UIScrollBar {
 
         Animation anim = new Animation(this, new AlphaTransform(from, to).forTicks(5));
 
-        event.getComponent().getGui().animate(anim);
+        event.getComponent()
+            .getGui()
+            .animate(anim);
     }
 }

--- a/src/main/java/net/malisis/core/client/gui/component/decoration/UIImage.java
+++ b/src/main/java/net/malisis/core/client/gui/component/decoration/UIImage.java
@@ -173,6 +173,6 @@ public class UIImage extends UIComponent<UIImage> {
     @Override
     public String getPropertyString() {
         return (itemStack != null ? itemStack : ("texture : " + this.texture + ", " + " icon : " + icon))
-                + super.getPropertyString();
+            + super.getPropertyString();
     }
 }

--- a/src/main/java/net/malisis/core/client/gui/component/decoration/UIProgressBar.java
+++ b/src/main/java/net/malisis/core/client/gui/component/decoration/UIProgressBar.java
@@ -36,8 +36,10 @@ public class UIProgressBar extends UIComponent<UIProgressBar> {
         setSize(22, 16);
 
         shape = new SimpleGuiShape();
-        barIcon = gui.getGuiTexture().getIcon(246, 0, 22, 16);
-        barFilledIcon = gui.getGuiTexture().getIcon(246, 16, 22, 16);
+        barIcon = gui.getGuiTexture()
+            .getIcon(246, 0, 22, 16);
+        barFilledIcon = gui.getGuiTexture()
+            .getIcon(246, 16, 22, 16);
     }
 
     public float getProgress() {

--- a/src/main/java/net/malisis/core/client/gui/component/decoration/UISeparator.java
+++ b/src/main/java/net/malisis/core/client/gui/component/decoration/UISeparator.java
@@ -34,7 +34,8 @@ public class UISeparator extends UIComponent<UISeparator> {
         this.vertical = vertical;
 
         shape = new XYResizableGuiShape(1);
-        icon = gui.getGuiTexture().getXYResizableIcon(200, 15, 15, 15, 3);
+        icon = gui.getGuiTexture()
+            .getXYResizableIcon(200, 15, 15, 15, 3);
 
         setSize(0, 0);
     }

--- a/src/main/java/net/malisis/core/client/gui/component/decoration/UITooltip.java
+++ b/src/main/java/net/malisis/core/client/gui/component/decoration/UITooltip.java
@@ -51,7 +51,8 @@ public class UITooltip extends UIComponent implements IGuiText<UITooltip> {
         fro.shadow = true;
 
         shape = new XYResizableGuiShape();
-        icon = gui.getGuiTexture().getXYResizableIcon(227, 31, 15, 15, 5);
+        icon = gui.getGuiTexture()
+            .getXYResizableIcon(227, 31, 15, 15, 5);
 
         animation = new Animation(this, new AlphaTransform(0, 255).forTicks(2));
     }

--- a/src/main/java/net/malisis/core/client/gui/component/interaction/UIButton.java
+++ b/src/main/java/net/malisis/core/client/gui/component/interaction/UIButton.java
@@ -71,10 +71,15 @@ public class UIButton extends UIComponent<UIButton> implements IGuiText<UIButton
         hoveredFro.shadow = true;
 
         shape = new XYResizableGuiShape();
-        icon = gui.getGuiTexture().getXYResizableIcon(0, 20, 200, 20, 5);
-        iconHovered = gui.getGuiTexture().getXYResizableIcon(0, 40, 200, 20, 5);
-        iconDisabled = gui.getGuiTexture().getXYResizableIcon(0, 0, 200, 20, 5);
-        iconPressed = (GuiIcon) gui.getGuiTexture().getXYResizableIcon(0, 40, 200, 20, 5).flip(true, true);
+        icon = gui.getGuiTexture()
+            .getXYResizableIcon(0, 20, 200, 20, 5);
+        iconHovered = gui.getGuiTexture()
+            .getXYResizableIcon(0, 40, 200, 20, 5);
+        iconDisabled = gui.getGuiTexture()
+            .getXYResizableIcon(0, 0, 200, 20, 5);
+        iconPressed = (GuiIcon) gui.getGuiTexture()
+            .getXYResizableIcon(0, 40, 200, 20, 5)
+            .flip(true, true);
     }
 
     /**

--- a/src/main/java/net/malisis/core/client/gui/component/interaction/UICheckBox.java
+++ b/src/main/java/net/malisis/core/client/gui/component/interaction/UICheckBox.java
@@ -57,11 +57,16 @@ public class UICheckBox extends UIComponent<UICheckBox> implements IGuiText<UICh
 
         shape = new SimpleGuiShape();
 
-        bgIcon = gui.getGuiTexture().getIcon(242, 32, 10, 10);
-        bgIconDisabled = gui.getGuiTexture().getIcon(252, 32, 10, 10);
-        cbDisabled = gui.getGuiTexture().getIcon(242, 42, 12, 10);
-        cbChecked = gui.getGuiTexture().getIcon(242, 52, 12, 10);
-        cbHovered = gui.getGuiTexture().getIcon(254, 42, 12, 10);
+        bgIcon = gui.getGuiTexture()
+            .getIcon(242, 32, 10, 10);
+        bgIconDisabled = gui.getGuiTexture()
+            .getIcon(252, 32, 10, 10);
+        cbDisabled = gui.getGuiTexture()
+            .getIcon(242, 42, 12, 10);
+        cbChecked = gui.getGuiTexture()
+            .getIcon(242, 52, 12, 10);
+        cbHovered = gui.getGuiTexture()
+            .getIcon(254, 42, 12, 10);
     }
 
     public UICheckBox(MalisisGui gui) {

--- a/src/main/java/net/malisis/core/client/gui/component/interaction/UIPasswordField.java
+++ b/src/main/java/net/malisis/core/client/gui/component/interaction/UIPasswordField.java
@@ -66,7 +66,9 @@ public class UIPasswordField extends UITextField {
      */
     protected void updateText() {
         this.text.setLength(0);
-        this.text.append(password.toString().replaceAll("(?s).", String.valueOf(passwordChar)));
+        this.text.append(
+            password.toString()
+                .replaceAll("(?s).", String.valueOf(passwordChar)));
     }
 
     /**
@@ -80,7 +82,8 @@ public class UIPasswordField extends UITextField {
 
         int position = cursorPosition.textPosition;
         String oldValue = password.toString();
-        String newValue = new StringBuilder(oldValue).insert(position, text).toString();
+        String newValue = new StringBuilder(oldValue).insert(position, text)
+            .toString();
 
         if (!validateText(newValue)) return;
 
@@ -132,6 +135,6 @@ public class UIPasswordField extends UITextField {
     @Override
     protected boolean handleCtrlKeyDown(int keyCode) {
         return GuiScreen.isCtrlKeyDown() && !(keyCode == Keyboard.KEY_C || keyCode == Keyboard.KEY_X)
-                && super.handleCtrlKeyDown(keyCode);
+            && super.handleCtrlKeyDown(keyCode);
     }
 }

--- a/src/main/java/net/malisis/core/client/gui/component/interaction/UIRadioButton.java
+++ b/src/main/java/net/malisis/core/client/gui/component/interaction/UIRadioButton.java
@@ -62,11 +62,16 @@ public class UIRadioButton extends UIComponent<UIRadioButton> implements IGuiTex
 
         shape = new SimpleGuiShape();
 
-        bgIcon = gui.getGuiTexture().getIcon(200, 54, 8, 8);
-        bgIconDisabled = gui.getGuiTexture().getIcon(200, 62, 8, 8);
-        rbDisabled = gui.getGuiTexture().getIcon(208, 54, 6, 6);
-        rbChecked = gui.getGuiTexture().getIcon(214, 54, 6, 6);
-        rbHovered = gui.getGuiTexture().getIcon(220, 54, 6, 6);
+        bgIcon = gui.getGuiTexture()
+            .getIcon(200, 54, 8, 8);
+        bgIconDisabled = gui.getGuiTexture()
+            .getIcon(200, 62, 8, 8);
+        rbDisabled = gui.getGuiTexture()
+            .getIcon(208, 54, 6, 6);
+        rbChecked = gui.getGuiTexture()
+            .getIcon(214, 54, 6, 6);
+        rbHovered = gui.getGuiTexture()
+            .getIcon(220, 54, 6, 6);
 
         addRadioButton(this);
     }

--- a/src/main/java/net/malisis/core/client/gui/component/interaction/UISelect.java
+++ b/src/main/java/net/malisis/core/client/gui/component/interaction/UISelect.java
@@ -51,7 +51,7 @@ import com.google.common.collect.Iterables;
  * @author Ordinastie
  */
 public class UISelect<T> extends UIComponent<UISelect<T>>
-        implements Iterable<Option<T>>, IClipable, IGuiText<UISelect<T>>, IScrollable {
+    implements Iterable<Option<T>>, IClipable, IGuiText<UISelect<T>>, IScrollable {
 
     /** The {@link MalisisFont} to use for this {@link UISelect}. */
     protected MalisisFont font = MalisisFont.minecraftFont;
@@ -152,10 +152,14 @@ public class UISelect<T> extends UIComponent<UISelect<T>>
         optionsShape = new XYResizableGuiShape(1);
         optionBackground = new SimpleGuiShape();
 
-        iconsSelect = gui.getGuiTexture().getXResizableIcon(200, 30, 9, 12, 3);
-        iconsSelectDisabled = gui.getGuiTexture().getXResizableIcon(200, 42, 9, 12, 3);
-        iconsExpanded = gui.getGuiTexture().getXYResizableIcon(200, 30, 9, 12, 1);
-        arrowIcon = gui.getGuiTexture().getIcon(209, 48, 7, 4);
+        iconsSelect = gui.getGuiTexture()
+            .getXResizableIcon(200, 30, 9, 12, 3);
+        iconsSelectDisabled = gui.getGuiTexture()
+            .getXResizableIcon(200, 42, 9, 12, 3);
+        iconsExpanded = gui.getGuiTexture()
+            .getXYResizableIcon(200, 30, 9, 12, 1);
+        arrowIcon = gui.getGuiTexture()
+            .getIcon(209, 48, 7, 4);
     }
 
     /**
@@ -341,7 +345,7 @@ public class UISelect<T> extends UIComponent<UISelect<T>>
     private void calcOptionsSize() {
         optionsWidth = getWidth() - 4;
         for (Option<?> option : this) optionsWidth = Math
-                .max(optionsWidth, (int) MalisisFont.minecraftFont.getStringWidth(option.getLabel(labelPattern)));
+            .max(optionsWidth, (int) MalisisFont.minecraftFont.getStringWidth(option.getLabel(labelPattern)));
 
         optionsWidth += 4;
         if (maxExpandedWidth > 0) optionsWidth = Math.min(maxExpandedWidth, optionsWidth);
@@ -368,7 +372,8 @@ public class UISelect<T> extends UIComponent<UISelect<T>>
     public UISelect<T> setOptions(Iterable<T> values) {
         if (values == null) values = Collections.EMPTY_LIST;
 
-        options = FluentIterable.from(values).transform(toOption);
+        options = FluentIterable.from(values)
+            .transform(toOption);
 
         calcOptionsSize();
         return this;
@@ -536,7 +541,8 @@ public class UISelect<T> extends UIComponent<UISelect<T>>
     protected int getSelectedIndex() {
         if (selectedOption == null) return 0;
 
-        for (int i = 0; i < options.size(); i++) if (options.get(i).equals(selectedOption)) return i;
+        for (int i = 0; i < options.size(); i++) if (options.get(i)
+            .equals(selectedOption)) return i;
         return 0;
     }
 
@@ -547,8 +553,8 @@ public class UISelect<T> extends UIComponent<UISelect<T>>
         if (!expanded || !isVisible()) return false;
 
         return x >= screenX() && x <= screenX() + optionsWidth
-                && y >= screenY() + 12
-                && y <= screenY() + 12 + optionsHeight;
+            && y >= screenY() + 12
+            && y <= screenY() + 12 + optionsHeight;
     }
 
     @Override
@@ -560,12 +566,12 @@ public class UISelect<T> extends UIComponent<UISelect<T>>
     @Override
     public ClipArea getClipArea() {
         return new ClipArea(
-                this,
-                screenX(),
-                screenY(),
-                screenX() + optionsWidth,
-                screenY() + optionsHeight + 12,
-                false);
+            this,
+            screenX(),
+            screenY(),
+            screenX() + optionsWidth,
+            screenY() + optionsHeight + 12,
+            false);
     }
 
     @Override
@@ -839,19 +845,19 @@ public class UISelect<T> extends UIComponent<UISelect<T>>
         }
 
         public void draw(UISelect select, GuiRenderer renderer, int x, int y, int z, float partialTick, boolean hovered,
-                boolean isTop) {
+            boolean isTop) {
             String text = getLabel(select.labelPattern);
             if (StringUtils.isEmpty(text)) return;
 
             if (hovered && !disabled) {
                 renderer.drawRectangle(
-                        x + 1,
-                        y - 1,
-                        z + 2,
-                        select.optionsWidth - 2,
-                        getHeight(select),
-                        select.getHoverBgColor(),
-                        255);
+                    x + 1,
+                    y - 1,
+                    z + 2,
+                    select.optionsWidth - 2,
+                    getHeight(select),
+                    select.getHoverBgColor(),
+                    255);
             }
 
             if (isTop) text = MalisisFont.minecraftFont.clipString(text, select.getWidth() - 15);

--- a/src/main/java/net/malisis/core/client/gui/component/interaction/UISlider.java
+++ b/src/main/java/net/malisis/core/client/gui/component/interaction/UISlider.java
@@ -73,8 +73,10 @@ public class UISlider extends UIComponent<UISlider> implements IGuiText<UISlider
         sliderShape.setSize(8, 20);
         sliderShape.storeState();
 
-        iconBackground = gui.getGuiTexture().getXResizableIcon(0, 0, 200, 20, 5);
-        sliderIcon = gui.getGuiTexture().getIcon(227, 46, 8, 20);
+        iconBackground = gui.getGuiTexture()
+            .getXResizableIcon(0, 0, 200, 20, 5);
+        sliderIcon = gui.getGuiTexture()
+            .getIcon(227, 46, 8, 20);
     }
 
     public UISlider(MalisisGui gui, int width, float min, float max) {

--- a/src/main/java/net/malisis/core/client/gui/component/interaction/UITextField.java
+++ b/src/main/java/net/malisis/core/client/gui/component/interaction/UITextField.java
@@ -137,8 +137,10 @@ public class UITextField extends UIComponent<UITextField> implements IScrollable
         cursorShape = new SimpleGuiShape();
         selectShape = new SimpleGuiShape();
 
-        iconTextfield = gui.getGuiTexture().getXYResizableIcon(200, 30, 9, 12, 1);
-        iconTextfieldDisabled = gui.getGuiTexture().getXYResizableIcon(200, 42, 9, 12, 1);
+        iconTextfield = gui.getGuiTexture()
+            .getXYResizableIcon(200, 30, 9, 12, 1);
+        iconTextfieldDisabled = gui.getGuiTexture()
+            .getXYResizableIcon(200, 42, 9, 12, 1);
 
         if (multiLine) scrollBar = new UISlimScrollbar(gui, this, Type.VERTICAL);
     }
@@ -622,7 +624,8 @@ public class UITextField extends UIComponent<UITextField> implements IScrollable
         int position = cursorPosition.textPosition;
 
         String oldValue = this.text.toString();
-        String newValue = new StringBuilder(oldValue).insert(position, str).toString();
+        String newValue = new StringBuilder(oldValue).insert(position, str)
+            .toString();
 
         if (!validateText(newValue)) return;
 
@@ -643,7 +646,8 @@ public class UITextField extends UIComponent<UITextField> implements IScrollable
         int end = Math.max(selectionPosition.textPosition, cursorPosition.textPosition);
 
         String oldValue = this.text.toString();
-        String newValue = new StringBuilder(oldValue).delete(start, end).toString();
+        String newValue = new StringBuilder(oldValue).delete(start, end)
+            .toString();
 
         if (!fireEvent(new ComponentEvent.ValueChange(this, oldValue, newValue))) return;
 
@@ -718,8 +722,7 @@ public class UITextField extends UIComponent<UITextField> implements IScrollable
             else if (text.length() != 0) {
                 // charOffset = 0;
                 while (font.getStringWidth(text.substring(charOffset, cursorPosition.textPosition), fro)
-                        >= getWidth() - 4)
-                    charOffset++;
+                    >= getWidth() - 4) charOffset++;
             }
         } else {
             if (cursorPosition.line < lineOffset) setLineOffset(cursorPosition.line);
@@ -1028,14 +1031,14 @@ public class UITextField extends UIComponent<UITextField> implements IScrollable
         if (cursorPosition.line < lineOffset || cursorPosition.line >= lineOffset + getVisibleLines()) return;
 
         renderer.drawRectangle(
-                cursorPosition.getXOffset() + 1,
-                cursorPosition.getYOffset() + 1,
-                getZIndex(),
-                1,
-                getLineHeight(),
-                cursorColor,
-                255,
-                true);
+            cursorPosition.getXOffset() + 1,
+            cursorPosition.getYOffset() + 1,
+            getZIndex(),
+            1,
+            getLineHeight(),
+            cursorColor,
+            255,
+            true);
     }
 
     /**
@@ -1049,7 +1052,7 @@ public class UITextField extends UIComponent<UITextField> implements IScrollable
         GL11.glLogicOp(GL11.GL_OR_REVERSE);
 
         CursorPosition first = cursorPosition.textPosition < selectionPosition.textPosition ? cursorPosition
-                : selectionPosition;
+            : selectionPosition;
         CursorPosition last = cursorPosition == first ? selectionPosition : cursorPosition;
 
         for (int i = first.line; i <= last.line; i++) {
@@ -1297,7 +1300,8 @@ public class UITextField extends UIComponent<UITextField> implements IScrollable
             textPosition = character;
             if (!multiLine) return;
 
-            for (int i = 0; i < line && i < lines.size(); i++) textPosition += lines.get(i).length();
+            for (int i = 0; i < line && i < lines.size(); i++) textPosition += lines.get(i)
+                .length();
 
             onCursorUpdated();
         }
@@ -1352,14 +1356,14 @@ public class UITextField extends UIComponent<UITextField> implements IScrollable
         @Override
         public String toString() {
             return "Pos : " + textPosition
-                    + " (l"
-                    + line
-                    + " / c"
-                    + character
-                    + ") at "
-                    + getXOffset()
-                    + ","
-                    + getYOffset();
+                + " (l"
+                + line
+                + " / c"
+                + character
+                + ") at "
+                + getXOffset()
+                + ","
+                + getYOffset();
         }
     }
 

--- a/src/main/java/net/malisis/core/client/gui/component/mceditor/EcfSelect.java
+++ b/src/main/java/net/malisis/core/client/gui/component/mceditor/EcfSelect.java
@@ -46,13 +46,17 @@ public class EcfSelect extends UISelect<EnumChatFormatting> {
 
     @Override
     public void setSelectedOption(Option<EnumChatFormatting> option) {
-        editor.getTextfield().addText(option.getKey().toString());
+        editor.getTextfield()
+            .addText(
+                option.getKey()
+                    .toString());
     }
 
     @Override
     public boolean onClick(int x, int y) {
         super.onClick(x, y);
-        if (!expanded) editor.getTextfield().setFocused(true);
+        if (!expanded) editor.getTextfield()
+            .setFocused(true);
         return true;
     }
 }

--- a/src/main/java/net/malisis/core/client/gui/component/mceditor/MCEditor.java
+++ b/src/main/java/net/malisis/core/client/gui/component/mceditor/MCEditor.java
@@ -42,12 +42,14 @@ public class MCEditor extends UIContainer<MCEditor> implements IGuiText<MCEditor
     public MCEditor(MalisisGui gui) {
         super(gui);
         tf = new UITextField(gui, true);
-        tf.setSize(0, -14).setAnchor(Anchor.BOTTOM);
+        tf.setSize(0, -14)
+            .setAnchor(Anchor.BOTTOM);
 
         sel = new EcfSelect(gui, this);
 
         cb = new UICheckBox(gui, "Use litteral formatting");
-        cb.setPosition(85, 0).register(this);
+        cb.setPosition(85, 0)
+            .register(this);
 
         add(tf, sel, cb);
     }

--- a/src/main/java/net/malisis/core/client/gui/element/GuiShape.java
+++ b/src/main/java/net/malisis/core/client/gui/element/GuiShape.java
@@ -69,10 +69,10 @@ public abstract class GuiShape extends Shape {
 
         public GuiFace() {
             super(
-                    new Vertex.BottomSouthWest().setBaseName("TopLeft"),
-                    new Vertex.TopSouthWest().setBaseName("BottomLeft"),
-                    new Vertex.TopSouthEast().setBaseName("BottomRight"),
-                    new Vertex.BottomSouthEast().setBaseName("TopRight"));
+                new Vertex.BottomSouthWest().setBaseName("TopLeft"),
+                new Vertex.TopSouthWest().setBaseName("BottomLeft"),
+                new Vertex.TopSouthEast().setBaseName("BottomRight"),
+                new Vertex.BottomSouthEast().setBaseName("TopRight"));
             setStandardUV();
         }
 

--- a/src/main/java/net/malisis/core/client/gui/event/ComponentExceptionHandler.java
+++ b/src/main/java/net/malisis/core/client/gui/event/ComponentExceptionHandler.java
@@ -30,8 +30,10 @@ public class ComponentExceptionHandler implements SubscriberExceptionHandler {
     @Override
     public void handleException(Throwable exception, SubscriberExceptionContext context) {
         MalisisCore.log.log(
-                Level.ERROR,
-                "An error occured wile processing event : " + context.getEvent().getClass().getSimpleName(),
-                exception);
+            Level.ERROR,
+            "An error occured wile processing event : " + context.getEvent()
+                .getClass()
+                .getSimpleName(),
+            exception);
     }
 }

--- a/src/main/java/net/malisis/core/configuration/ConfigurationGui.java
+++ b/src/main/java/net/malisis/core/configuration/ConfigurationGui.java
@@ -66,7 +66,10 @@ public class ConfigurationGui extends MalisisGui {
         UIWindow window = new UIWindow(this, "config.title", windowWidth, windowHeight);
 
         for (String category : categories) {
-            windowHeight = Math.max(windowHeight, (settings.getSettings(category).size() * 14 + 40));
+            windowHeight = Math.max(
+                windowHeight,
+                (settings.getSettings(category)
+                    .size() * 14 + 40));
             window.add(createSettingContainer(category));
         }
 
@@ -79,8 +82,10 @@ public class ConfigurationGui extends MalisisGui {
         panelComment.setBackgroundColor(0xCCCCCC);
         panelComment.add(comment);
 
-        btnCancel = new UIButton(this, "gui.cancel").setPosition(-32, 0, Anchor.BOTTOM | Anchor.CENTER).register(this);
-        btnSave = new UIButton(this, "gui.done").setPosition(32, 0, Anchor.BOTTOM | Anchor.CENTER).register(this);
+        btnCancel = new UIButton(this, "gui.cancel").setPosition(-32, 0, Anchor.BOTTOM | Anchor.CENTER)
+            .register(this);
+        btnSave = new UIButton(this, "gui.done").setPosition(32, 0, Anchor.BOTTOM | Anchor.CENTER)
+            .register(this);
 
         window.add(panelComment);
         window.add(btnCancel);
@@ -92,7 +97,7 @@ public class ConfigurationGui extends MalisisGui {
     private UIContainer createSettingContainer(String category) {
         List<Setting> categorySettings = settings.getSettings(category);
         UIContainer container = new UIContainer<UIContainer>(this, windowWidth - 105, windowHeight - 35)
-                .setPosition(5, 12);
+            .setPosition(5, 12);
 
         int y = 0;
         for (Setting setting : categorySettings) {

--- a/src/main/java/net/malisis/core/configuration/Settings.java
+++ b/src/main/java/net/malisis/core/configuration/Settings.java
@@ -60,12 +60,12 @@ public class Settings {
     protected void initSettings() {}
 
     private void getSettingFields() {
-        Field[] fields = this.getClass().getDeclaredFields();
+        Field[] fields = this.getClass()
+            .getDeclaredFields();
         for (Field field : fields) {
             ConfigurationSetting annotation;
             if ((annotation = field.getAnnotation(ConfigurationSetting.class)) == null
-                    || field.getType() != Setting.class)
-                continue;
+                || field.getType() != Setting.class) continue;
 
             Setting setting = null;
             try {

--- a/src/main/java/net/malisis/core/configuration/setting/DoubleSetting.java
+++ b/src/main/java/net/malisis/core/configuration/setting/DoubleSetting.java
@@ -54,7 +54,8 @@ public class DoubleSetting extends Setting<Double> {
     @Override
     public UIComponent getComponent(MalisisGui gui) {
         UILabel label = new UILabel(gui, key);
-        textField = new UITextField(gui, writeValue(value)).setSize(50, 0).setPosition(label.getWidth() + 2, 0);
+        textField = new UITextField(gui, writeValue(value)).setSize(50, 0)
+            .setPosition(label.getWidth() + 2, 0);
 
         UIContainer container = new UIContainer(gui, label.getWidth() + 54, 12);
         container.add(label);

--- a/src/main/java/net/malisis/core/configuration/setting/IntegerSetting.java
+++ b/src/main/java/net/malisis/core/configuration/setting/IntegerSetting.java
@@ -52,7 +52,8 @@ public class IntegerSetting extends Setting<Integer> {
     @Override
     public UIComponent getComponent(MalisisGui gui) {
         UILabel label = new UILabel(gui, key);
-        textField = new UITextField(gui, writeValue(value)).setSize(50, 0).setPosition(label.getWidth() + 2, 0);
+        textField = new UITextField(gui, writeValue(value)).setSize(50, 0)
+            .setPosition(label.getWidth() + 2, 0);
 
         UIContainer container = new UIContainer(gui, label.getWidth() + 54, 12);
         container.add(label);

--- a/src/main/java/net/malisis/core/configuration/setting/StringSetting.java
+++ b/src/main/java/net/malisis/core/configuration/setting/StringSetting.java
@@ -48,7 +48,8 @@ public class StringSetting extends Setting<String> {
     @Override
     public UIComponent getComponent(MalisisGui gui) {
         UILabel label = new UILabel(gui, key);
-        textField = new UITextField(gui, writeValue(value)).setSize(50, 0).setPosition(label.getWidth() + 2, 0);
+        textField = new UITextField(gui, writeValue(value)).setSize(50, 0)
+            .setPosition(label.getWidth() + 2, 0);
 
         UIContainer container = new UIContainer(gui, label.getWidth() + 54, 12);
         container.add(label);

--- a/src/main/java/net/malisis/core/inventory/MalisisInventory.java
+++ b/src/main/java/net/malisis/core/inventory/MalisisInventory.java
@@ -50,7 +50,7 @@ public class MalisisInventory implements IInventory {
 
     /** List of {@link MalisisInventory} that is currently containing this {@link MalisisInventory}. */
     protected Set<MalisisInventoryContainer> containers = Collections
-            .newSetFromMap(new WeakHashMap<MalisisInventoryContainer, Boolean>());
+        .newSetFromMap(new WeakHashMap<MalisisInventoryContainer, Boolean>());
     /** The inventory id inside the container. */
     protected int inventoryId;
     /** Object containing this {@link MalisisInventory}. */
@@ -320,14 +320,15 @@ public class MalisisInventory implements IInventory {
      */
     public void setItemStackProvider(ItemStack itemStack) {
         if (!(inventoryProvider instanceof Item)) throw new IllegalArgumentException(
-                "setItemStack not allowed with " + inventoryProvider.getClass().getSimpleName() + " provider.");
+            "setItemStack not allowed with " + inventoryProvider.getClass()
+                .getSimpleName() + " provider.");
 
         if (itemStack.getItem() != inventoryProvider) {
             MalisisCore.log.error(
-                    "[MalisisInventory] Tried to set itemStack with an different item (" + itemStack.getItem()
-                            + ") than the provider ("
-                            + inventoryProvider
-                            + ")");
+                "[MalisisInventory] Tried to set itemStack with an different item (" + itemStack.getItem()
+                    + ") than the provider ("
+                    + inventoryProvider
+                    + ")");
             return;
         }
 
@@ -554,8 +555,8 @@ public class MalisisInventory implements IInventory {
     @Override
     public String toString() {
         String provider = "Player";
-        if (!(this instanceof PlayerInventory))
-            provider = inventoryProvider != null ? inventoryProvider.getClass().getSimpleName() : "null	";
+        if (!(this instanceof PlayerInventory)) provider = inventoryProvider != null ? inventoryProvider.getClass()
+            .getSimpleName() : "null	";
 
         return (name != null ? name : getClass().getSimpleName()) + " (" + inventoryId + ") from " + provider;
     }
@@ -569,7 +570,7 @@ public class MalisisInventory implements IInventory {
      * @return the malisis inventory container
      */
     public static MalisisInventoryContainer open(EntityPlayerMP player, IInventoryProvider inventoryProvider,
-            Object... data) {
+        Object... data) {
         if (inventoryProvider == null) return null;
 
         MalisisInventoryContainer c = new MalisisInventoryContainer(player, 0);
@@ -598,7 +599,7 @@ public class MalisisInventory implements IInventory {
      */
     @SideOnly(Side.CLIENT)
     public static MalisisInventoryContainer open(EntityClientPlayerMP player, IInventoryProvider inventoryProvider,
-            int windowId, Object... data) {
+        int windowId, Object... data) {
         if (inventoryProvider == null) return null;
 
         MalisisInventoryContainer c = new MalisisInventoryContainer(player, windowId);
@@ -609,7 +610,9 @@ public class MalisisInventory implements IInventory {
             inv.bus.post(new InventoryEvent.Open(c, inv));
         }
 
-        if (FMLCommonHandler.instance().getSide().isClient()) {
+        if (FMLCommonHandler.instance()
+            .getSide()
+            .isClient()) {
             MalisisGui gui = inventoryProvider.getGui(c);
             if (gui != null) gui.display();
         }

--- a/src/main/java/net/malisis/core/inventory/MalisisInventoryContainer.java
+++ b/src/main/java/net/malisis/core/inventory/MalisisInventoryContainer.java
@@ -261,7 +261,7 @@ public class MalisisInventoryContainer extends Container {
             if (inventory.getInventoryId() != 0) {
                 ArrayList<MalisisSlot> slots = new ArrayList<>(Arrays.asList(inventory.getSlots()));
                 UpdateInventorySlotsMessage
-                        .updateSlots(inventory.getInventoryId(), slots, (EntityPlayerMP) owner, windowId);
+                    .updateSlots(inventory.getInventoryId(), slots, (EntityPlayerMP) owner, windowId);
             }
         }
     }
@@ -296,7 +296,7 @@ public class MalisisInventoryContainer extends Container {
         }
 
         if (changedSlots.size() > 0) UpdateInventorySlotsMessage
-                .updateSlots(inventory.getInventoryId(), changedSlots, (EntityPlayerMP) owner, windowId);
+            .updateSlots(inventory.getInventoryId(), changedSlots, (EntityPlayerMP) owner, windowId);
     }
 
     /**
@@ -349,28 +349,34 @@ public class MalisisInventoryContainer extends Container {
         MalisisInventory inv = inventories.get(inventoryId);
         if (inv == null) {
             MalisisCore.log.error(
-                    "[MalisisInventoryContainer] Tried to handle an action for a wrong inventory (" + inventoryId
-                            + ").");
+                "[MalisisInventoryContainer] Tried to handle an action for a wrong inventory (" + inventoryId + ").");
             return null;
         }
         MalisisSlot slot = inv.getSlot(slotNumber);
         if (slot == null) {
             MalisisCore.log.error(
-                    "[MalisisInventoryContainer] Tried to handle an action for a wrong slotNumber (" + slotNumber
-                            + ").");
+                "[MalisisInventoryContainer] Tried to handle an action for a wrong slotNumber (" + slotNumber + ").");
             return null;
         }
 
         if (slot.isState(FROZEN)) return pickedItemStack;
 
         // first check if current slot is current providing inventory (for Items providing inventory)
-        if (slot.getItemStack() != null && slot.getItemStack().getItem() instanceof IInventoryProvider
-                && slot.getItemStack().getTagCompound() != null) {
-            if (slot.getItemStack().getTagCompound().getInteger("inventoryId") == 1) {
+        if (slot.getItemStack() != null && slot.getItemStack()
+            .getItem() instanceof IInventoryProvider
+            && slot.getItemStack()
+                .getTagCompound() != null) {
+            if (slot.getItemStack()
+                .getTagCompound()
+                .getInteger("inventoryId") == 1) {
                 owner.closeScreen();
                 return null;
-            } else if (slot.getItemStack().getTagCompound().hasKey("inventoryId"))
-                slot.getItemStack().getTagCompound().removeTag("inventoryId");
+            } else if (slot.getItemStack()
+                .getTagCompound()
+                .hasKey("inventoryId"))
+                slot.getItemStack()
+                    .getTagCompound()
+                    .removeTag("inventoryId");
         }
 
         // player pressed 1-9 key while hovering a slot
@@ -467,7 +473,8 @@ public class MalisisInventoryContainer extends Container {
             if (!slot.isState(PLAYER_EXTRACT)) return null;
             if (!inventories.get(0).state.is(PLAYER_INSERT)) return null;
 
-            itemStack = inventories.get(0).transferInto(itemStack);
+            itemStack = inventories.get(0)
+                .transferInto(itemStack);
 
             slot.setItemStack(itemStack);
             // if (slot.hasChanged())
@@ -503,7 +510,8 @@ public class MalisisInventoryContainer extends Container {
      */
     private ItemStack handleHotbar(MalisisSlot slot, int num) {
         boolean fromPlayerInv = slot instanceof PlayerInventorySlot;
-        MalisisSlot hotbarSlot = inventories.get(0).getSlot(num);
+        MalisisSlot hotbarSlot = inventories.get(0)
+            .getSlot(num);
 
         // slot from player's inventory, swap itemStacks
         if (fromPlayerInv || slot.getItemStack() == null) {
@@ -516,7 +524,8 @@ public class MalisisInventoryContainer extends Container {
                 if (dest != null) {
                     hotbarSlot.insert(dest);
                     // src should be null but better safe than sorry
-                    inventories.get(0).transferInto(src);
+                    inventories.get(0)
+                        .transferInto(src);
                 } else src = hotbarSlot.insert(src);
             }
         }
@@ -525,7 +534,8 @@ public class MalisisInventoryContainer extends Container {
             if (slot.isState(PLAYER_EXTRACT)) {
                 ItemStack dest = slot.extract(ItemUtils.FULL_STACK);
                 ItemStack left = hotbarSlot.insert(dest, ItemUtils.FULL_STACK, true);
-                inventories.get(0).transferInto(left, false);
+                inventories.get(0)
+                    .transferInto(left, false);
             }
         }
 
@@ -575,7 +585,8 @@ public class MalisisInventoryContainer extends Container {
             while (pickedItemStack.stackSize < pickedItemStack.getMaxStackSize() && i < inventory.size) {
                 if (slot.isState(PLAYER_EXTRACT)) {
                     MalisisSlot s = inventory.getSlot(i);
-                    if (s.getItemStack() != null && s.getItemStack().stackSize != s.getItemStack().getMaxStackSize()) {
+                    if (s.getItemStack() != null && s.getItemStack().stackSize != s.getItemStack()
+                        .getMaxStackSize()) {
                         ItemUtils.ItemStacksMerger ism = new ItemStacksMerger(s.getItemStack(), pickedItemStack);
                         ism.merge();
                         s.setItemStack(ism.merge);
@@ -596,7 +607,8 @@ public class MalisisInventoryContainer extends Container {
                 ItemStack itemStack = s.getItemStack();
                 if (slot.isState(PLAYER_EXTRACT) && ItemUtils.areItemStacksStackable(itemStack, lastShiftClicked)) {
                     if (inventoryId != 0) {
-                        itemStack = inventories.get(0).transferInto(itemStack);
+                        itemStack = inventories.get(0)
+                            .transferInto(itemStack);
                         s.setItemStack(itemStack);
                         // if (s.hasChanged())
                         s.onSlotChanged();
@@ -630,7 +642,8 @@ public class MalisisInventoryContainer extends Container {
     private ItemStack handlePickBlock(MalisisSlot slot) {
         if (slot.getItemStack() == null || pickedItemStack != null) return null;
 
-        ItemStack itemStack = slot.getItemStack().copy();
+        ItemStack itemStack = slot.getItemStack()
+            .copy();
         itemStack.stackSize = itemStack.getMaxStackSize();
         setPickedItemStack(itemStack);
 

--- a/src/main/java/net/malisis/core/inventory/MalisisSlot.java
+++ b/src/main/java/net/malisis/core/inventory/MalisisSlot.java
@@ -344,7 +344,7 @@ public class MalisisSlot {
         ItemStack cached = cachedItemStacks.get(player);
         ItemStack cachedDragged = cachedDraggedItemStacks.get(player);
         return !ItemStack.areItemStacksEqual(itemStack, cached)
-                || !ItemStack.areItemStacksEqual(draggedItemStack, cachedDragged);
+            || !ItemStack.areItemStacksEqual(draggedItemStack, cachedDragged);
     }
 
     /**

--- a/src/main/java/net/malisis/core/inventory/message/CloseInventoryMessage.java
+++ b/src/main/java/net/malisis/core/inventory/message/CloseInventoryMessage.java
@@ -63,7 +63,8 @@ public class CloseInventoryMessage implements IMessageHandler<CloseInventoryMess
      */
     @SideOnly(Side.CLIENT)
     private void closeGui() {
-        if (MalisisGui.currentGui() != null) MalisisGui.currentGui().close();
+        if (MalisisGui.currentGui() != null) MalisisGui.currentGui()
+            .close();
     }
 
     /**

--- a/src/main/java/net/malisis/core/inventory/message/OpenInventoryMessage.java
+++ b/src/main/java/net/malisis/core/inventory/message/OpenInventoryMessage.java
@@ -79,7 +79,7 @@ public class OpenInventoryMessage implements IMessageHandler<OpenInventoryMessag
         IInventoryProvider inventoryProvider = null;
         Object data = null;
         if (type == ContainerType.TYPE_TILEENTITY) inventoryProvider = TileEntityUtils
-                .getTileEntity(IInventoryProvider.class, Minecraft.getMinecraft().theWorld, x, y, z);
+            .getTileEntity(IInventoryProvider.class, Minecraft.getMinecraft().theWorld, x, y, z);
         else if (type == ContainerType.TYPE_ITEM) {
             ItemStack itemStack = player.getCurrentEquippedItem();
             if (itemStack != null && itemStack.getItem() instanceof IInventoryProvider) {

--- a/src/main/java/net/malisis/core/network/MalisisNetwork.java
+++ b/src/main/java/net/malisis/core/network/MalisisNetwork.java
@@ -90,16 +90,16 @@ public class MalisisNetwork extends SimpleNetworkWrapper {
      * @param side               the side
      */
     public <REQ extends IMessage, REPLY extends IMessage> void registerMessage(
-            Class<? extends IMessageHandler<REQ, REPLY>> messageHandler, Class<REQ> requestMessageType, Side side) {
+        Class<? extends IMessageHandler<REQ, REPLY>> messageHandler, Class<REQ> requestMessageType, Side side) {
         super.registerMessage(messageHandler, requestMessageType, discriminator++, side);
         MalisisCore.log.info(
-                "Registering " + messageHandler.getSimpleName()
-                        + " for "
-                        + requestMessageType.getSimpleName()
-                        + " with discriminator "
-                        + discriminator
-                        + " in channel "
-                        + name);
+            "Registering " + messageHandler.getSimpleName()
+                + " for "
+                + requestMessageType.getSimpleName()
+                + " with discriminator "
+                + discriminator
+                + " in channel "
+                + name);
     }
 
     /**
@@ -112,16 +112,17 @@ public class MalisisNetwork extends SimpleNetworkWrapper {
      * @param side               the side
      */
     public <REQ extends IMessage, REPLY extends IMessage> void registerMessage(
-            IMessageHandler<? super REQ, ? extends REPLY> messageHandler, Class<REQ> requestMessageType, Side side) {
+        IMessageHandler<? super REQ, ? extends REPLY> messageHandler, Class<REQ> requestMessageType, Side side) {
         super.registerMessage(messageHandler, requestMessageType, discriminator++, side);
         MalisisCore.log.info(
-                "Registering " + messageHandler.getClass().getSimpleName()
-                        + " for "
-                        + requestMessageType.getSimpleName()
-                        + " with discriminator "
-                        + discriminator
-                        + " in channel "
-                        + name);
+            "Registering " + messageHandler.getClass()
+                .getSimpleName()
+                + " for "
+                + requestMessageType.getSimpleName()
+                + " with discriminator "
+                + discriminator
+                + " in channel "
+                + name);
     }
 
     /**
@@ -139,21 +140,22 @@ public class MalisisNetwork extends SimpleNetworkWrapper {
      * @param asmDataTable the asm data table
      */
     public static void createMessages(ASMDataTable asmDataTable) {
-        List<ASMData> classes = Ordering.natural().onResultOf(new Function<ASMData, String>() {
+        List<ASMData> classes = Ordering.natural()
+            .onResultOf(new Function<ASMData, String>() {
 
-            @Override
-            public String apply(ASMData data) {
-                return data.getClassName();
-            }
-        }).sortedCopy(asmDataTable.getAll(MalisisMessage.class.getName()));
+                @Override
+                public String apply(ASMData data) {
+                    return data.getClassName();
+                }
+            })
+            .sortedCopy(asmDataTable.getAll(MalisisMessage.class.getName()));
 
         for (ASMData data : classes) {
             try {
                 Class clazz = Class.forName(data.getClassName());
                 if (IMessageHandler.class.isAssignableFrom(clazz)) clazz.newInstance();
-                else MalisisCore.log.error(
-                        "@MalisisMessage found on {} that does not implement IMessageHandler",
-                        data.getClassName());
+                else MalisisCore.log
+                    .error("@MalisisMessage found on {} that does not implement IMessageHandler", data.getClassName());
             } catch (Exception e) {
                 MalisisCore.log.error("Could not create {} message.", data.getClassName(), e);
             }

--- a/src/main/java/net/malisis/core/renderer/MalisisRenderer.java
+++ b/src/main/java/net/malisis/core/renderer/MalisisRenderer.java
@@ -64,7 +64,7 @@ import cpw.mods.fml.client.registry.RenderingRegistry;
  *
  */
 public class MalisisRenderer extends TileEntitySpecialRenderer
-        implements ISimpleBlockRenderingHandler, IItemRenderer, IRenderWorldLast {
+    implements ISimpleBlockRenderingHandler, IItemRenderer, IRenderWorldLast {
 
     // Reference to Minecraft.renderGlobal.damagedBlocks (lazy loaded)
     /** The damaged blocks. */
@@ -285,7 +285,7 @@ public class MalisisRenderer extends TileEntitySpecialRenderer
      */
     @Override
     public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId,
-            RenderBlocks renderer) {
+        RenderBlocks renderer) {
         set(world, block, x, y, z, world.getBlockMetadata(x, y, z));
         tileEntity = world.getTileEntity(x, y, z);
         renderBlocks = renderer;
@@ -596,7 +596,9 @@ public class MalisisRenderer extends TileEntitySpecialRenderer
 
     @Override
     protected void bindTexture(ResourceLocation resourceLocaltion) {
-        Minecraft.getMinecraft().getTextureManager().bindTexture(resourceLocaltion);
+        Minecraft.getMinecraft()
+            .getTextureManager()
+            .bindTexture(resourceLocaltion);
     }
 
     // #end prepare()
@@ -714,8 +716,8 @@ public class MalisisRenderer extends TileEntitySpecialRenderer
         int vertexCount = f.getVertexes().length;
         if (vertexCount != 4 && renderType == RenderType.ISBRH_WORLD) {
             MalisisCore.log.error(
-                    "[MalisisRenderer] Attempting to render a face containing {} vertexes in ISBRH. Ignored",
-                    vertexCount);
+                "[MalisisRenderer] Attempting to render a face containing {} vertexes in ISBRH. Ignored",
+                vertexCount);
             return;
         }
 
@@ -728,7 +730,7 @@ public class MalisisRenderer extends TileEntitySpecialRenderer
 
         // use normals if available
         if ((renderType == RenderType.ITEM_INVENTORY || renderType == RenderType.ISBRH_INVENTORY
-                || params.useNormals.get()) && params.direction.get() != null)
+            || params.useNormals.get()) && params.direction.get() != null)
             t.setNormal(params.direction.get().offsetX, params.direction.get().offsetY, params.direction.get().offsetZ);
 
         baseBrightness = getBaseBrightness();
@@ -737,9 +739,8 @@ public class MalisisRenderer extends TileEntitySpecialRenderer
 
         // we need to separate each face
         if (drawMode == GL11.GL_POLYGON || drawMode == GL11.GL_LINE
-                || drawMode == GL11.GL_LINE_STRIP
-                || drawMode == GL11.GL_LINE_LOOP)
-            next();
+            || drawMode == GL11.GL_LINE_STRIP
+            || drawMode == GL11.GL_LINE_LOOP) next();
     }
 
     /**
@@ -811,7 +812,8 @@ public class MalisisRenderer extends TileEntitySpecialRenderer
         else if (overrideTexture != null) icon = overrideTexture;
         else if (block != null && icon == null) {
             int side = 0;
-            if (params.textureSide.get() != null) side = params.textureSide.get().ordinal();
+            if (params.textureSide.get() != null) side = params.textureSide.get()
+                .ordinal();
             if (world != null && params.useWorldSensitiveIcon.get()) icon = block.getIcon(world, x, y, z, side);
             else icon = block.getIcon(side, blockMetadata);
         }
@@ -839,7 +841,8 @@ public class MalisisRenderer extends TileEntitySpecialRenderer
         else if (block != null && icon == null) {
             int side = 0;
             if (faceParams.textureSide.merged(globalOverrides.textureSide) != null)
-                side = faceParams.textureSide.merged(globalOverrides.textureSide).ordinal();
+                side = faceParams.textureSide.merged(globalOverrides.textureSide)
+                    .ordinal();
             if (world != null && faceParams.useWorldSensitiveIcon.merged(globalOverrides.useWorldSensitiveIcon))
                 icon = block.getIcon(world, x, y, z, side);
             else icon = block.getIcon(side, blockMetadata);
@@ -863,11 +866,12 @@ public class MalisisRenderer extends TileEntitySpecialRenderer
         if (p.direction.get() == null || p.renderAllFaces.get()) return true;
 
         boolean b = block.shouldSideBeRendered(
-                world,
-                x + p.direction.get().offsetX,
-                y + p.direction.get().offsetY,
-                z + p.direction.get().offsetZ,
-                p.direction.get().ordinal());
+            world,
+            x + p.direction.get().offsetX,
+            y + p.direction.get().offsetY,
+            z + p.direction.get().offsetZ,
+            p.direction.get()
+                .ordinal());
         return b;
     }
 
@@ -936,13 +940,13 @@ public class MalisisRenderer extends TileEntitySpecialRenderer
         float factor = 1;
         // calculate AO
         if (params.calculateAOColor.get() && aoMatrix != null
-                && Minecraft.isAmbientOcclusionEnabled()
-                && block.getLightValue(world, x, y, z) == 0) {
+            && Minecraft.isAmbientOcclusionEnabled()
+            && block.getLightValue(world, x, y, z) == 0) {
             factor = getBlockAmbientOcclusion(
-                    world,
-                    x + params.direction.get().offsetX,
-                    y + params.direction.get().offsetY,
-                    z + params.direction.get().offsetZ);
+                world,
+                x + params.direction.get().offsetX,
+                y + params.direction.get().offsetY,
+                z + params.direction.get().offsetZ);
 
             for (int i = 0; i < aoMatrix.length; i++)
                 factor += getBlockAmbientOcclusion(world, x + aoMatrix[i][0], y + aoMatrix[i][1], z + aoMatrix[i][2]);
@@ -1081,7 +1085,8 @@ public class MalisisRenderer extends TileEntitySpecialRenderer
      */
     protected int getMixedBrightnessForBlock(IBlockAccess world, int x, int y, int z) {
         // return world.getLightBrightnessForSkyBlocks(x, y, z, 0);
-        return world.getBlock(x, y, z).getMixedBrightnessForBlock(world, x, y, z);
+        return world.getBlock(x, y, z)
+            .getMixedBrightnessForBlock(world, x, y, z);
     }
 
     /**
@@ -1096,12 +1101,12 @@ public class MalisisRenderer extends TileEntitySpecialRenderer
         if (world != null) block.setBlockBoundsBasedOnState(world, x, y, z);
 
         return AxisAlignedBB.getBoundingBox(
-                block.getBlockBoundsMinX(),
-                block.getBlockBoundsMinY(),
-                block.getBlockBoundsMinZ(),
-                block.getBlockBoundsMaxX(),
-                block.getBlockBoundsMaxY(),
-                block.getBlockBoundsMaxZ());
+            block.getBlockBoundsMinX(),
+            block.getBlockBoundsMinY(),
+            block.getBlockBoundsMinZ(),
+            block.getBlockBoundsMaxX(),
+            block.getBlockBoundsMaxY(),
+            block.getBlockBoundsMaxZ());
     }
 
     /**
@@ -1149,7 +1154,8 @@ public class MalisisRenderer extends TileEntitySpecialRenderer
         Map damagedBlocks = getDamagedBlocks();
         if (damagedBlocks == null || damagedBlocks.isEmpty()) return null;
 
-        Iterator iterator = damagedBlocks.values().iterator();
+        Iterator iterator = damagedBlocks.values()
+            .iterator();
         while (iterator.hasNext()) {
             DestroyBlockProgress dbp = (DestroyBlockProgress) iterator.next();
             if (isCurrentBlockDestroyProgress(dbp)) return dbp;
@@ -1188,12 +1194,13 @@ public class MalisisRenderer extends TileEntitySpecialRenderer
         for (Class clazz : listClass) {
             if (Block.class.isAssignableFrom(clazz)) {
                 try {
-                    clazz.getField("renderId").set(null, renderId);
+                    clazz.getField("renderId")
+                        .set(null, renderId);
                     RenderingRegistry.registerBlockHandler(this);
                 } catch (ReflectiveOperationException e) {
                     MalisisCore.log.error(
-                            "[MalisisRenderer] Tried to register ISBRH for block class {} that does not have renderId field",
-                            clazz.getSimpleName());
+                        "[MalisisRenderer] Tried to register ISBRH for block class {} that does not have renderId field",
+                        clazz.getSimpleName());
                     e.printStackTrace();
                 }
             } else if (TileEntity.class.isAssignableFrom(clazz)) {

--- a/src/main/java/net/malisis/core/renderer/RenderParameters.java
+++ b/src/main/java/net/malisis/core/renderer/RenderParameters.java
@@ -148,10 +148,10 @@ public class RenderParameters implements ITransformable.Color, ITransformable.Al
 
     public RenderParameters() {
         listParams = new Parameter<?>[] { renderAllFaces, useBlockBounds, renderBounds,
-                vertexPositionRelativeToRenderBounds, useCustomTexture, applyTexture, icon, useWorldSensitiveIcon,
-                useTexture, interpolateUV, calculateAOColor, calculateBrightness, usePerVertexColor, usePerVertexAlpha,
-                usePerVertexBrightness, useEnvironmentBrightness, useNormals, colorMultiplier, colorFactor, brightness,
-                alpha, direction, textureSide, aoMatrix, flipU, flipV, };
+            vertexPositionRelativeToRenderBounds, useCustomTexture, applyTexture, icon, useWorldSensitiveIcon,
+            useTexture, interpolateUV, calculateAOColor, calculateBrightness, usePerVertexColor, usePerVertexAlpha,
+            usePerVertexBrightness, useEnvironmentBrightness, useNormals, colorMultiplier, colorFactor, brightness,
+            alpha, direction, textureSide, aoMatrix, flipU, flipV, };
     }
 
     public RenderParameters(RenderParameters params) {

--- a/src/main/java/net/malisis/core/renderer/RenderParameters.java
+++ b/src/main/java/net/malisis/core/renderer/RenderParameters.java
@@ -164,6 +164,15 @@ public class RenderParameters implements ITransformable.Color, ITransformable.Al
         return listParams[index];
     }
 
+    public void init() {
+        this.renderAllFaces.set(true);
+        this.calculateAOColor.set(false);
+        this.useBlockBounds.set(false);
+        this.useEnvironmentBrightness.set(false);
+        this.calculateBrightness.set(false);
+        this.interpolateUV.set(false);
+    }
+
     public void reset() {
         for (Parameter param : listParams) {
             param.reset();

--- a/src/main/java/net/malisis/core/renderer/animation/transformation/Scale.java
+++ b/src/main/java/net/malisis/core/renderer/animation/transformation/Scale.java
@@ -61,11 +61,11 @@ public class Scale extends Transformation<Scale, ITransformable.Scale> {
         float toZ = reversed ? this.fromZ : this.toZ;
 
         transformable.scale(
-                fromX + (toX - fromX) * comp,
-                fromY + (toY - fromY) * comp,
-                fromZ + (toZ - fromZ) * comp,
-                offsetX,
-                offsetY,
-                offsetZ);
+            fromX + (toX - fromX) * comp,
+            fromY + (toY - fromY) * comp,
+            fromZ + (toZ - fromZ) * comp,
+            offsetX,
+            offsetY,
+            offsetZ);
     }
 }

--- a/src/main/java/net/malisis/core/renderer/animation/transformation/SizeTransform.java
+++ b/src/main/java/net/malisis/core/renderer/animation/transformation/SizeTransform.java
@@ -91,7 +91,7 @@ public class SizeTransform<T> extends Transformation<SizeTransform, ITransformab
         int toHeight = reversed ? this.fromHeight : this.toHeight;
 
         transformable.setSize(
-                (int) (fromWidth + (toWidth - fromWidth) * comp),
-                (int) (fromHeight + (toHeight - fromHeight) * comp));
+            (int) (fromWidth + (toWidth - fromWidth) * comp),
+            (int) (fromHeight + (toHeight - fromHeight) * comp));
     }
 }

--- a/src/main/java/net/malisis/core/renderer/animation/transformation/Translation.java
+++ b/src/main/java/net/malisis/core/renderer/animation/transformation/Translation.java
@@ -51,6 +51,6 @@ public class Translation extends Transformation<Translation, ITransformable.Tran
         float toZ = reversed ? this.fromZ : this.toZ;
 
         transformable
-                .translate(fromX + (toX - fromX) * comp, fromY + (toY - fromY) * comp, fromZ + (toZ - fromZ) * comp);
+            .translate(fromX + (toX - fromX) * comp, fromY + (toY - fromY) * comp, fromZ + (toZ - fromZ) * comp);
     }
 }

--- a/src/main/java/net/malisis/core/renderer/element/Face.java
+++ b/src/main/java/net/malisis/core/renderer/element/Face.java
@@ -172,19 +172,11 @@ public class Face implements ITransformable.Translate, ITransformable.Rotate {
         float U = 1;
         float V = 1;
 
-        double factorU, factorV;
-
-        float[][] uvs = new float[vertexes.length][2];
-        for (int i = 0; i < vertexes.length; i++) {
-            Vertex vertex = vertexes[i];
-
-            factorU = getFactorU(vertex);
-            factorV = getFactorV(vertex);
-
-            uvs[i] = new float[] { interpolate(u, U, factorU, false), interpolate(v, V, factorV, false) };
+        for (Vertex vertex : vertexes) {
+            vertex.setUV(
+                interpolate(u, U, getFactorU(vertex), false),
+                interpolate(v, V, getFactorV(vertex), false));
         }
-
-        for (int i = 0; i < vertexes.length; i++) vertexes[i].setUV(uvs[i][0], uvs[i][1]);
 
         return this;
     }

--- a/src/main/java/net/malisis/core/renderer/element/Face.java
+++ b/src/main/java/net/malisis/core/renderer/element/Face.java
@@ -153,15 +153,14 @@ public class Face implements ITransformable.Translate, ITransformable.Rotate {
 
         double factorU, factorV;
 
-        float uvs[][] = new float[vertexes.length][2];
+        float[][] uvs = new float[vertexes.length][2];
         for (int i = 0; i < vertexes.length; i++) {
             Vertex vertex = vertexes[i];
 
             factorU = getFactorU(vertex);
             factorV = getFactorV(vertex);
 
-            int k = i;
-            uvs[k] = new float[] { interpolate(u, U, factorU, false), interpolate(v, V, factorV, false) };
+            uvs[i] = new float[] { interpolate(u, U, factorU, false), interpolate(v, V, factorV, false) };
         }
 
         for (int i = 0; i < vertexes.length; i++) vertexes[i].setUV(uvs[i][0], uvs[i][1]);

--- a/src/main/java/net/malisis/core/renderer/element/Face.java
+++ b/src/main/java/net/malisis/core/renderer/element/Face.java
@@ -28,6 +28,8 @@ public class Face implements ITransformable.Translate, ITransformable.Rotate {
     protected String name;
     protected Vertex[] vertexes;
     protected RenderParameters params;
+    private static final int[] dirs = { Vertex.NORTH, Vertex.SOUTH, Vertex.EAST, Vertex.WEST, Vertex.UP, Vertex.DOWN };
+    private static final String[] strdirs = { "North", "South", "East", "West", "Top", "Bottom" };
 
     public Face(Vertex[] vertexes, RenderParameters params) {
         this.vertexes = vertexes;
@@ -64,14 +66,14 @@ public class Face implements ITransformable.Translate, ITransformable.Rotate {
     public void setName(String name) {
         if (name == null) {
             name = "";
-            HashMap<String, Integer> map = new HashMap<String, Integer>();
-            String[] dirs = new String[] { "North", "South", "East", "West", "Top", "Bottom" };
-            for (String dir : dirs) {
+            HashMap<Integer, Integer> map = new HashMap<>();
+
+            for (int dir : Face.dirs) {
                 map.put(dir, 0);
                 for (Vertex v : vertexes) {
-                    if (v.name().contains(dir)) map.put(dir, map.get(dir) + 1);
+                    if ((v.getDirectionFlags() & dir) != 0) map.put(dir, map.get(dir) + 1);
                 }
-                if (map.get(dir) == 4) name = dir;
+                if (map.get(dir) == 4) name = strdirs[Integer.numberOfTrailingZeros(dir)];
             }
         }
 
@@ -406,7 +408,7 @@ public class Face implements ITransformable.Translate, ITransformable.Rotate {
     @Override
     public String toString() {
         String s = name() + " {";
-        for (Vertex v : vertexes) s += v.name() + ", ";
+        for (Vertex v : vertexes) s += v + ", ";
         return s + "}";
     }
 

--- a/src/main/java/net/malisis/core/renderer/element/Face.java
+++ b/src/main/java/net/malisis/core/renderer/element/Face.java
@@ -13,7 +13,6 @@
 
 package net.malisis.core.renderer.element;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
@@ -174,9 +173,7 @@ public class Face implements ITransformable.Translate, ITransformable.Rotate {
         float V = 1;
 
         for (Vertex vertex : vertexes) {
-            vertex.setUV(
-                interpolate(u, U, getFactorU(vertex), false),
-                interpolate(v, V, getFactorV(vertex), false));
+            vertex.setUV(interpolate(u, U, getFactorU(vertex), false), interpolate(v, V, getFactorV(vertex), false));
         }
 
         return this;
@@ -366,9 +363,9 @@ public class Face implements ITransformable.Translate, ITransformable.Rotate {
 
         int factor = 1000;
         Vector normal = new Vector(
-                (float) Math.round(x * factor) / factor,
-                (float) Math.round(y * factor) / factor,
-                (float) Math.round(z * factor) / factor);
+            (float) Math.round(x * factor) / factor,
+            (float) Math.round(y * factor) / factor,
+            (float) Math.round(z * factor) / factor);
         normal.normalize();
         return normal;
     }

--- a/src/main/java/net/malisis/core/renderer/element/Face.java
+++ b/src/main/java/net/malisis/core/renderer/element/Face.java
@@ -29,6 +29,7 @@ public class Face implements ITransformable.Translate, ITransformable.Rotate {
     protected String name;
     protected Vertex[] vertexes;
     protected RenderParameters params = new RenderParameters();
+    private final float[][] scratch = new float[4][2];
     private static final int[] dirs = { Vertex.NORTH, Vertex.SOUTH, Vertex.EAST, Vertex.WEST, Vertex.UP, Vertex.DOWN };
     private static final String[] strdirs = { "North", "South", "East", "West", "Top", "Bottom" };
 
@@ -191,7 +192,6 @@ public class Face implements ITransformable.Translate, ITransformable.Rotate {
 
         double factorU, factorV;
 
-        float uvs[][] = new float[vertexes.length][2];
         for (int i = 0; i < vertexes.length; i++) {
             Vertex vertex = vertexes[i];
 
@@ -202,10 +202,12 @@ public class Face implements ITransformable.Translate, ITransformable.Rotate {
             if (icon instanceof MalisisIcon) {
                 k = (i + ((MalisisIcon) icon).getRotation()) % vertexes.length;
             }
-            uvs[k] = new float[] { interpolate(u, U, factorU, flippedU), interpolate(v, V, factorV, flippedV) };
+
+            this.scratch[k][0] = interpolate(u, U, factorU, flippedU);
+            this.scratch[k][1] = interpolate(v, V, factorV, flippedV);
         }
 
-        for (int i = 0; i < vertexes.length; i++) vertexes[i].setUV(uvs[i][0], uvs[i][1]);
+        for (int i = 0; i < vertexes.length; i++) vertexes[i].setUV(this.scratch[i][0], this.scratch[i][1]);
 
         return this;
     }
@@ -215,11 +217,9 @@ public class Face implements ITransformable.Translate, ITransformable.Rotate {
 
         switch (params.direction.get()) {
             case EAST:
-                return vertex.getZ();
             case WEST:
                 return vertex.getZ();
             case NORTH:
-                return vertex.getX();
             case SOUTH:
             case UP:
             case DOWN:

--- a/src/main/java/net/malisis/core/renderer/element/Face.java
+++ b/src/main/java/net/malisis/core/renderer/element/Face.java
@@ -31,6 +31,10 @@ public class Face implements ITransformable.Translate, ITransformable.Rotate {
     private static final int[] dirs = { Vertex.NORTH, Vertex.SOUTH, Vertex.EAST, Vertex.WEST, Vertex.UP, Vertex.DOWN };
     private static final String[] strdirs = { "North", "South", "East", "West", "Top", "Bottom" };
 
+    public void reset() {
+
+    }
+
     public Face(Vertex[] vertexes, RenderParameters params) {
         this.vertexes = vertexes;
         this.params = params != null ? params : new RenderParameters();

--- a/src/main/java/net/malisis/core/renderer/element/Face.java
+++ b/src/main/java/net/malisis/core/renderer/element/Face.java
@@ -13,6 +13,7 @@
 
 package net.malisis.core.renderer.element;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
@@ -27,7 +28,7 @@ public class Face implements ITransformable.Translate, ITransformable.Rotate {
 
     protected String name;
     protected Vertex[] vertexes;
-    protected RenderParameters params;
+    protected RenderParameters params = new RenderParameters();
     private static final int[] dirs = { Vertex.NORTH, Vertex.SOUTH, Vertex.EAST, Vertex.WEST, Vertex.UP, Vertex.DOWN };
     private static final String[] strdirs = { "North", "South", "East", "West", "Top", "Bottom" };
 
@@ -37,7 +38,7 @@ public class Face implements ITransformable.Translate, ITransformable.Rotate {
 
     public Face(Vertex[] vertexes, RenderParameters params) {
         this.vertexes = vertexes;
-        this.params = params != null ? params : new RenderParameters();
+        this.params = params != null ? params : this.params;
         this.setName(null);
     }
 
@@ -57,8 +58,24 @@ public class Face implements ITransformable.Translate, ITransformable.Rotate {
         Vertex[] faceVertexes = face.getVertexes();
         this.vertexes = new Vertex[faceVertexes.length];
         for (int i = 0; i < faceVertexes.length; i++) vertexes[i] = new Vertex(faceVertexes[i]);
-        this.params = params != null ? params : new RenderParameters();
+        this.params = params != null ? params : this.params;
         name = face.name;
+    }
+
+    public void copy(Face f) {
+        this.params.merge(f.params);
+
+        boolean init = false;
+        if (this.vertexes.length != f.vertexes.length) {
+            this.vertexes = new Vertex[f.vertexes.length];
+            init = true;
+        }
+
+        for (int i = 0; i < f.vertexes.length; ++i) {
+            if (init) this.vertexes[i] = new Vertex(f.vertexes[i]);
+            else this.vertexes[i].setState(f.vertexes[i]);
+        }
+        this.name = f.name;
     }
 
     /**

--- a/src/main/java/net/malisis/core/renderer/element/MergedVertex.java
+++ b/src/main/java/net/malisis/core/renderer/element/MergedVertex.java
@@ -19,10 +19,11 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import lombok.Getter;
 import net.malisis.core.renderer.animation.transformation.ITransformable;
 
 import org.joml.Matrix4f;
+
+import lombok.Getter;
 
 /**
  * MergedVertex are holders of vertex that share the same position inside a shape. The position is determined by the
@@ -34,7 +35,7 @@ import org.joml.Matrix4f;
  *
  */
 public class MergedVertex implements ITransformable.Translate, ITransformable.Rotate, ITransformable.Scale,
-        ITransformable.Alpha, ITransformable.Color, ITransformable.Brightness, Iterable<Vertex> {
+    ITransformable.Alpha, ITransformable.Color, ITransformable.Brightness, Iterable<Vertex> {
 
     @Getter
     protected String name;
@@ -122,7 +123,8 @@ public class MergedVertex implements ITransformable.Translate, ITransformable.Ro
     public boolean is(String... names) {
         boolean b = true;
         for (String n : names) {
-            b &= name.toLowerCase().contains(n.toLowerCase());
+            b &= name.toLowerCase()
+                .contains(n.toLowerCase());
         }
         return b;
     }

--- a/src/main/java/net/malisis/core/renderer/element/MergedVertex.java
+++ b/src/main/java/net/malisis/core/renderer/element/MergedVertex.java
@@ -19,10 +19,10 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import lombok.Getter;
 import net.malisis.core.renderer.animation.transformation.ITransformable;
 
-import org.lwjgl.util.vector.Matrix4f;
-import org.lwjgl.util.vector.Vector3f;
+import org.joml.Matrix4f;
 
 /**
  * MergedVertex are holders of vertex that share the same position inside a shape. The position is determined by the
@@ -36,17 +36,17 @@ import org.lwjgl.util.vector.Vector3f;
 public class MergedVertex implements ITransformable.Translate, ITransformable.Rotate, ITransformable.Scale,
         ITransformable.Alpha, ITransformable.Color, ITransformable.Brightness, Iterable<Vertex> {
 
-    /** Name of this {@link MergedVertex}. */
+    @Getter
     protected String name;
 
-    /** Base {@link Vertex}. */
+    @Getter
     protected Vertex base;
 
     /** Matrix holding the tranformations applied to this {@link MergedVertex}. */
     protected Matrix4f transformMatrix = new Matrix4f();
 
     /** List of {@link Vertex vertexes} that share the same position. */
-    private Set<Vertex> vertexes = new HashSet<>();
+    private final Set<Vertex> vertexes = new HashSet<>();
 
     /**
      * Instantiates a new {@link MergedVertex}.
@@ -57,24 +57,6 @@ public class MergedVertex implements ITransformable.Translate, ITransformable.Ro
         this.name = vertex.baseName();
         this.base = vertex;
         addVertex(vertex);
-    }
-
-    /**
-     * Gets the name of this {@link MergedVertex}.
-     *
-     * @return the name of this {@link MergedVertex}.
-     */
-    public String getName() {
-        return name;
-    }
-
-    /**
-     * Gets the base {@link Vertex} for this {@link MergedVertex}.
-     *
-     * @return the base
-     */
-    public Vertex getBase() {
-        return base;
     }
 
     /**
@@ -167,8 +149,8 @@ public class MergedVertex implements ITransformable.Translate, ITransformable.Ro
     }
 
     private void resetMatrix() {
-        transformMatrix.setIdentity();
-        transformMatrix.translate(new Vector3f(0.5F, 0.5F, 0.5F));
+        transformMatrix.identity();
+        transformMatrix.translate(0.5F, 0.5F, 0.5F);
     }
 
     /**
@@ -184,7 +166,7 @@ public class MergedVertex implements ITransformable.Translate, ITransformable.Ro
      * Applies the transformations matrices to this {@link MergedVertex}. This modifies the position of the vertexes.
      */
     public void applyMatrix() {
-        transformMatrix.translate(new Vector3f(-0.5F, -0.5F, -0.5F));
+        transformMatrix.translate(-0.5F, -0.5F, -0.5F);
 
         for (Vertex v : vertexes) v.applyMatrix(transformMatrix);
 
@@ -202,7 +184,7 @@ public class MergedVertex implements ITransformable.Translate, ITransformable.Ro
      */
     @Override
     public void translate(float x, float y, float z) {
-        transformMatrix.translate(new Vector3f(x, y, z));
+        transformMatrix.translate(x, y, z);
     }
 
     /**
@@ -219,7 +201,7 @@ public class MergedVertex implements ITransformable.Translate, ITransformable.Ro
     @Override
     public void rotate(float angle, float x, float y, float z, float offsetX, float offsetY, float offsetZ) {
         translate(offsetX, offsetY, offsetZ);
-        transformMatrix.rotate((float) Math.toRadians(angle), new Vector3f(x, y, z));
+        transformMatrix.rotate((float) Math.toRadians(angle), x, y, z);
         translate(-offsetX, -offsetY, -offsetZ);
     }
 
@@ -236,7 +218,7 @@ public class MergedVertex implements ITransformable.Translate, ITransformable.Ro
     @Override
     public void scale(float x, float y, float z, float offsetX, float offsetY, float offsetZ) {
         translate(offsetX, offsetY, offsetZ);
-        transformMatrix.scale(new Vector3f(x, y, z));
+        transformMatrix.scale(x, y, z);
         translate(-offsetX, -offsetY, -offsetZ);
     }
 

--- a/src/main/java/net/malisis/core/renderer/element/Shape.java
+++ b/src/main/java/net/malisis/core/renderer/element/Shape.java
@@ -357,10 +357,10 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
         float x = 0, y = 0, z = 0;
         for (Face f : faces) {
             for (Vertex v : f.getVertexes()) {
-                String name = v.baseName();
-                if (name.contains("West")) x = (float) v.getX();
-                if (name.contains("Bottom")) y = (float) v.getY();
-                if (name.contains("North")) z = (float) v.getZ();
+                final int flags = v.getDirectionFlags();
+                if ((flags & Vertex.WEST) != 0) x = (float) v.getX();
+                if ((flags & Vertex.DOWN) != 0) y = (float) v.getY();
+                if ((flags & Vertex.NORTH) != 0) z = (float) v.getZ();
             }
         }
 
@@ -392,13 +392,13 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
     public Shape setBounds(double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
         for (Face f : faces) {
             for (Vertex v : f.getVertexes()) {
-                String name = v.name();
-                if (name.contains("West")) v.setX(minX);
-                if (name.contains("East")) v.setX(maxX);
-                if (name.contains("Bottom")) v.setY(minY);
-                if (name.contains("Top")) v.setY(maxY);
-                if (name.contains("North")) v.setZ(minZ);
-                if (name.contains("South")) v.setZ(maxZ);
+                final int flags = v.getDirectionFlags();
+                if ((flags & Vertex.WEST) != 0) v.setX(minX);
+                if ((flags & Vertex.EAST) != 0) v.setX(maxX);
+                if ((flags & Vertex.DOWN) != 0) v.setY(minY);
+                if ((flags & Vertex.UP) != 0) v.setY(maxY);
+                if ((flags & Vertex.NORTH) != 0) v.setZ(minZ);
+                if ((flags & Vertex.SOUTH) != 0) v.setZ(maxZ);
             }
         }
         return this;
@@ -576,10 +576,8 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
         if (face == null) return this;
         enableMergedVertexes();
 
-        HashMap<String, Vertex> vertexNames = new HashMap<String, Vertex>();
         double x = 0, y = 0, z = 0;
         for (Vertex v : face.getVertexes()) {
-            vertexNames.put(v.name(), v);
             x += v.getX() / 4;
             y += v.getY() / 4;
             z += v.getZ() / 4;

--- a/src/main/java/net/malisis/core/renderer/element/Shape.java
+++ b/src/main/java/net/malisis/core/renderer/element/Shape.java
@@ -261,7 +261,7 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
 
     // #end VERTEXES
 
-    private void resetMatrix() {
+    protected void resetMatrix() {
         transformMatrix.identity();
         transformMatrix.translate(0.5F, 0.5F, 0.5F);
     }
@@ -273,7 +273,7 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
      * @return the shape
      */
     public Shape copyMatrix(Shape shape) {
-        this.transformMatrix = new Matrix4f(shape.transformMatrix);
+        this.transformMatrix.set(shape.transformMatrix);
         return this;
     }
 

--- a/src/main/java/net/malisis/core/renderer/element/Shape.java
+++ b/src/main/java/net/malisis/core/renderer/element/Shape.java
@@ -49,6 +49,13 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
         resetMatrix();
     }
 
+    public void reset() {
+        for (Face f : this.faces)
+            f.reset();
+        this.resetMatrix();
+        if (this.mergedVertexes != null) this.mergedVertexes.clear();
+    }
+
     /**
      * Instantiates a new {@link Shape}.
      */

--- a/src/main/java/net/malisis/core/renderer/element/Shape.java
+++ b/src/main/java/net/malisis/core/renderer/element/Shape.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import lombok.Getter;
 import net.malisis.core.renderer.MalisisRenderer;
 import net.malisis.core.renderer.RenderParameters;
 import net.malisis.core.renderer.animation.transformation.ITransformable;
@@ -26,7 +25,8 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.joml.Matrix4f;
-import org.lwjgl.Sys;
+
+import lombok.Getter;
 
 /**
  * Base class for anything drawn with a {@link MalisisRenderer}. Supports basic transformations like scaling,
@@ -51,8 +51,7 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
     }
 
     public void reset() {
-        for (Face f : this.faces)
-            f.reset();
+        for (Face f : this.faces) f.reset();
         this.resetMatrix();
         if (this.mergedVertexes != null) this.mergedVertexes.clear();
     }
@@ -102,8 +101,7 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
     }
 
     public Shape copy(Shape s) {
-        if (this.faces.length != s.faces.length)
-            this.faces = new Face[s.faces.length];
+        if (this.faces.length != s.faces.length) this.faces = new Face[s.faces.length];
 
         for (int i = 0; i < s.faces.length; ++i) this.faces[i].copy(s.faces[i]);
         this.copyMatrix(s);
@@ -146,7 +144,8 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
      */
     public List<Face> getFaces(String name) {
         List<Face> list = new ArrayList<>();
-        for (Face f : faces) if (f.name().equalsIgnoreCase(name)) list.add(f);
+        for (Face f : faces) if (f.name()
+            .equalsIgnoreCase(name)) list.add(f);
         return list;
     }
 
@@ -205,7 +204,9 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
         List<Vertex> vertexes = new ArrayList<>();
         for (Face f : faces) {
             for (Vertex v : f.getVertexes()) {
-                if (v.baseName().toLowerCase().contains(name.toLowerCase())) vertexes.add(v);
+                if (v.baseName()
+                    .toLowerCase()
+                    .contains(name.toLowerCase())) vertexes.add(v);
             }
         }
         return vertexes;
@@ -334,7 +335,8 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
      * @return this {@link Shape}
      */
     public Shape setParameters(RenderParameters params, boolean merge) {
-        for (Face f : faces) if (merge) f.getParameters().merge(params);
+        for (Face f : faces) if (merge) f.getParameters()
+            .merge(params);
         else f.setParameters(params);
 
         return this;
@@ -353,7 +355,8 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
         for (Face f : this.faces) {
             if (!f.name.equalsIgnoreCase(name)) continue;
 
-            if (merge) f.getParameters().merge(params);
+            if (merge) f.getParameters()
+                .merge(params);
             else f.setParameters(params);
         }
         return this;
@@ -637,11 +640,9 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
     public Shape takeShapes(Shape... shapes) {
 
         int size = 0;
-        for (int i = 0; i < shapes.length; ++i)
-            size += shapes[i].faces.length;
+        for (int i = 0; i < shapes.length; ++i) size += shapes[i].faces.length;
 
-        if (this.faces.length != size)
-            this.faces = new Face[size];
+        if (this.faces.length != size) this.faces = new Face[size];
 
         size = 0;
         for (int i = 0; i < shapes.length; ++i) {
@@ -664,12 +665,10 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
         int size = 0;
         for (int i = 0; i < shapes.length; ++i) {
             size += shapes[i].faces.length;
-            for (Face f : shapes[i].faces)
-                f.setName(groupNames[i]);
+            for (Face f : shapes[i].faces) f.setName(groupNames[i]);
         }
 
-        if (this.faces.length != size)
-            this.faces = new Face[size];
+        if (this.faces.length != size) this.faces = new Face[size];
 
         size = 0;
         for (int i = 0; i < shapes.length; ++i) {

--- a/src/main/java/net/malisis/core/renderer/element/Shape.java
+++ b/src/main/java/net/malisis/core/renderer/element/Shape.java
@@ -14,10 +14,10 @@
 package net.malisis.core.renderer.element;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import lombok.Getter;
 import net.malisis.core.renderer.MalisisRenderer;
 import net.malisis.core.renderer.RenderParameters;
 import net.malisis.core.renderer.animation.transformation.ITransformable;
@@ -25,8 +25,7 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.lwjgl.util.vector.Matrix4f;
-import org.lwjgl.util.vector.Vector3f;
+import org.joml.Matrix4f;
 
 /**
  * Base class for anything drawn with a {@link MalisisRenderer}. Supports basic transformations like scaling,
@@ -37,7 +36,7 @@ import org.lwjgl.util.vector.Vector3f;
  */
 public class Shape implements ITransformable.Translate, ITransformable.Rotate, ITransformable.Scale {
 
-    /** {@link Face Faces} making up this {@link Shape} */
+    @Getter
     protected Face[] faces;
 
     /** The matrix containing all the transformations applied to this {@link Shape}. */
@@ -116,15 +115,6 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
     }
 
     /**
-     * Gets the {@link Face faces} that make up this {@link Shape}.
-     *
-     * @return the faces
-     */
-    public Face[] getFaces() {
-        return faces;
-    }
-
-    /**
      * Gets the {@link Face faces} that make up this {@link Shape} which match the specified <b>name</b>.
      *
      * @param name the name
@@ -132,7 +122,7 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
      */
     public List<Face> getFaces(String name) {
         List<Face> list = new ArrayList<>();
-        for (Face f : faces) if (f.name().toLowerCase().equals(name.toLowerCase())) list.add(f);
+        for (Face f : faces) if (f.name().equalsIgnoreCase(name)) list.add(f);
         return list;
     }
 
@@ -144,7 +134,7 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
      */
     public Face getFace(String name) {
         List<Face> list = getFaces(name);
-        return list.size() > 0 ? list.get(0) : null;
+        return !list.isEmpty() ? list.get(0) : null;
     }
 
     /**
@@ -272,8 +262,8 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
     // #end VERTEXES
 
     private void resetMatrix() {
-        transformMatrix.setIdentity();
-        transformMatrix.translate(new Vector3f(0.5F, 0.5F, 0.5F));
+        transformMatrix.identity();
+        transformMatrix.translate(0.5F, 0.5F, 0.5F);
     }
 
     /**
@@ -301,7 +291,7 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
         }
 
         // transform back to original place
-        transformMatrix.translate(new Vector3f(-0.5F, -0.5F, -0.5F));
+        transformMatrix.translate(-0.5F, -0.5F, -0.5F);
 
         for (Face f : faces) {
             for (Vertex v : f.getVertexes()) if (v != null) v.applyMatrix(transformMatrix);
@@ -447,7 +437,7 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
     public void translate(float x, float y, float z) {
         if (mergedVertexes != null) {
             for (MergedVertex mv : mergedVertexes.values()) mv.translate(x, y, z);
-        } else transformMatrix.translate(new Vector3f(x, y, z));
+        } else transformMatrix.translate(x, y, z);
     }
 
     /**
@@ -486,7 +476,7 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
             for (MergedVertex mv : mergedVertexes.values()) mv.scale(x, y, z, offsetX, offsetY, offsetZ);
         } else {
             translate(offsetX, offsetY, offsetZ);
-            transformMatrix.scale(new Vector3f(x, y, z));
+            transformMatrix.scale(x, y, z);
             translate(-offsetX, -offsetY, -offsetZ);
         }
     }
@@ -520,7 +510,7 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
             for (MergedVertex mv : mergedVertexes.values()) mv.rotate(angle, x, y, z, offsetX, offsetY, offsetZ);
         } else {
             translate(offsetX, offsetY, offsetZ);
-            transformMatrix.rotate((float) Math.toRadians(angle), new Vector3f(x, y, z));
+            transformMatrix.rotate((float) Math.toRadians(angle), x, y, z);
             translate(-offsetX, -offsetY, -offsetZ);
         }
     }

--- a/src/main/java/net/malisis/core/renderer/element/Shape.java
+++ b/src/main/java/net/malisis/core/renderer/element/Shape.java
@@ -93,6 +93,15 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
         copyMatrix(s);
     }
 
+    public Shape copy(Shape s) {
+        if (this.faces.length != s.faces.length)
+            this.faces = new Face[s.faces.length];
+
+        for (int i = 0; i < s.faces.length; ++i) this.faces[i].copy(s.faces[i]);
+        this.copyMatrix(s);
+        return this;
+    }
+
     // #region FACES
     /**
      * Adds {@link Face faces} to this {@link Shape}.

--- a/src/main/java/net/malisis/core/renderer/element/Shape.java
+++ b/src/main/java/net/malisis/core/renderer/element/Shape.java
@@ -26,6 +26,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.joml.Matrix4f;
+import org.lwjgl.Sys;
 
 /**
  * Base class for anything drawn with a {@link MalisisRenderer}. Supports basic transformations like scaling,
@@ -61,6 +62,13 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
      */
     public Shape() {
         this.faces = new Face[0];
+    }
+
+    /**
+     * Instantiates a new {@link Shape}.
+     */
+    public Shape(int capacity) {
+        this.faces = new Face[capacity];
     }
 
     /**
@@ -342,8 +350,9 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
      * @return this {@link Shape}
      */
     public Shape setParameters(String name, RenderParameters params, boolean merge) {
-        List<Face> faces = getFaces(name);
-        for (Face f : faces) {
+        for (Face f : this.faces) {
+            if (!f.name.equalsIgnoreCase(name)) continue;
+
             if (merge) f.getParameters().merge(params);
             else f.setParameters(params);
         }
@@ -617,5 +626,57 @@ public class Shape implements ITransformable.Translate, ITransformable.Rotate, I
         }
 
         return new Shape(faces);
+    }
+
+    /**
+     * Builds a {@link Shape} from multiple ones. This is a shallow copy!
+     *
+     * @param shapes the shapes
+     * @return self
+     */
+    public Shape takeShapes(Shape... shapes) {
+
+        int size = 0;
+        for (int i = 0; i < shapes.length; ++i)
+            size += shapes[i].faces.length;
+
+        if (this.faces.length != size)
+            this.faces = new Face[size];
+
+        size = 0;
+        for (int i = 0; i < shapes.length; ++i) {
+            shapes[i].applyMatrix();
+            System.arraycopy(shapes[i].faces, 0, this.faces, size, shapes[i].faces.length);
+            size += shapes[i].faces.length;
+        }
+
+        return this;
+    }
+
+    /**
+     * See {@link #addFaces(Face[], String)}. This takes the faces from shapes. This is a shallow copy!
+     *
+     * @param shapes the shapes
+     * @return self
+     */
+    public Shape takeFaces(String[] groupNames, Shape... shapes) {
+
+        int size = 0;
+        for (int i = 0; i < shapes.length; ++i) {
+            size += shapes[i].faces.length;
+            for (Face f : shapes[i].faces)
+                f.setName(groupNames[i]);
+        }
+
+        if (this.faces.length != size)
+            this.faces = new Face[size];
+
+        size = 0;
+        for (int i = 0; i < shapes.length; ++i) {
+            System.arraycopy(shapes[i].faces, 0, this.faces, size, shapes[i].faces.length);
+            size += shapes[i].faces.length;
+        }
+
+        return this;
     }
 }

--- a/src/main/java/net/malisis/core/renderer/element/Vertex.java
+++ b/src/main/java/net/malisis/core/renderer/element/Vertex.java
@@ -385,7 +385,7 @@ public class Vertex {
         z = vec.z;
     }
 
-    private void setState(Vertex vertex) {
+    public void setState(Vertex vertex) {
         x = vertex.x;
         y = vertex.y;
         z = vertex.z;
@@ -394,6 +394,8 @@ public class Vertex {
         alpha = vertex.alpha;
         u = vertex.u;
         v = vertex.v;
+        baseName = vertex.baseName;
+        directionFlags = vertex.directionFlags;
     }
 
     public void setInitialState() {

--- a/src/main/java/net/malisis/core/renderer/element/Vertex.java
+++ b/src/main/java/net/malisis/core/renderer/element/Vertex.java
@@ -13,6 +13,7 @@
 
 package net.malisis.core.renderer.element;
 
+import lombok.Getter;
 import net.malisis.core.util.Point;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -83,6 +84,15 @@ public class Vertex {
     private int alpha = 255;
     private double u = 0.0F;
     private double v = 0.0F;
+    @Getter
+    private int directionFlags = 0;
+
+    public static final int DOWN = 0x1 << ForgeDirection.DOWN.ordinal();
+    public static final int UP = 0x1 << ForgeDirection.UP.ordinal();
+    public static final int NORTH = 0x1 << ForgeDirection.NORTH.ordinal();
+    public static final int SOUTH = 0x1 << ForgeDirection.SOUTH.ordinal();
+    public static final int WEST = 0x1 << ForgeDirection.WEST.ordinal();
+    public static final int EAST = 0x1 << ForgeDirection.EAST.ordinal();
 
     private Vertex initialState;
 
@@ -119,6 +129,7 @@ public class Vertex {
                 vertex.v,
                 false);
         baseName = vertex.baseName;
+        directionFlags = vertex.directionFlags;
     }
 
     public Vertex(Vertex vertex, int rgba, int brightness) {
@@ -337,19 +348,19 @@ public class Vertex {
     public String baseName() {
         if (baseName == null) {
             baseName = "";
-            if (isCorner())
+            if (isCorner()) {
+                directionFlags |= (y == 1) ? UP : DOWN;
+                directionFlags |= (z == 1) ? SOUTH : NORTH;
+                directionFlags |= (x == 1) ? EAST : WEST;
                 baseName = (y == 1 ? "Top" : "Bottom") + (z == 1 ? "South" : "North") + (x == 1 ? "East" : "West");
+            }
         }
         return baseName;
     }
 
-    public String name() {
-        return baseName() + " [" + x + ", " + y + ", " + z + "|" + u + ", " + v + "]";
-    }
-
     @Override
     public String toString() {
-        return name() + " 0x" + Integer.toHexString(color) + " (a:" + alpha + ", b:" + brightness + ")";
+        return "0x" + Integer.toHexString(color) + " (a:" + alpha + ", b:" + brightness + ")";
     }
 
     public Point toPoint() {

--- a/src/main/java/net/malisis/core/renderer/element/Vertex.java
+++ b/src/main/java/net/malisis/core/renderer/element/Vertex.java
@@ -13,14 +13,14 @@
 
 package net.malisis.core.renderer.element;
 
-import lombok.Getter;
 import net.malisis.core.util.Point;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.joml.Matrix4f;
 import org.joml.Vector3f;
-import org.joml.Vector4f;
+
+import lombok.Getter;
 
 public class Vertex {
 
@@ -121,14 +121,14 @@ public class Vertex {
 
     public Vertex(Vertex vertex) {
         this(
-                vertex.x,
-                vertex.y,
-                vertex.z,
-                vertex.color << 8 | vertex.alpha,
-                vertex.brightness,
-                vertex.u,
-                vertex.v,
-                false);
+            vertex.x,
+            vertex.y,
+            vertex.z,
+            vertex.color << 8 | vertex.alpha,
+            vertex.brightness,
+            vertex.u,
+            vertex.v,
+            false);
         baseName = vertex.baseName;
         directionFlags = vertex.directionFlags;
     }

--- a/src/main/java/net/malisis/core/renderer/element/Vertex.java
+++ b/src/main/java/net/malisis/core/renderer/element/Vertex.java
@@ -18,8 +18,9 @@ import net.malisis.core.util.Point;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import org.lwjgl.util.vector.Matrix4f;
-import org.lwjgl.util.vector.Vector4f;
+import org.joml.Matrix4f;
+import org.joml.Vector3f;
+import org.joml.Vector4f;
 
 public class Vertex {
 
@@ -378,8 +379,8 @@ public class Vertex {
     }
 
     public void applyMatrix(Matrix4f transformMatrix) {
-        Vector4f vec = new Vector4f((float) x, (float) y, (float) z, 1F);
-        Matrix4f.transform(transformMatrix, vec, vec);
+        Vector3f vec = new Vector3f((float) x, (float) y, (float) z);
+        vec.mulPosition(transformMatrix);
         x = vec.x;
         y = vec.y;
         z = vec.z;

--- a/src/main/java/net/malisis/core/renderer/element/face/BottomFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/BottomFace.java
@@ -24,12 +24,25 @@ import net.malisis.core.renderer.element.Vertex;
  */
 public class BottomFace extends Face {
 
+    private static final Vertex[] DEFAULT = {
+        new Vertex.BottomNorthEast(),
+        new Vertex.BottomSouthEast(),
+        new Vertex.BottomSouthWest(),
+        new Vertex.BottomNorthWest()
+    };
+
+    public void reset() {
+        for (int i = 0; i < 4; ++i) {
+            this.vertexes[i].setState(DEFAULT[i]);
+        }
+    }
+
     public BottomFace() {
         super(
-                new Vertex.BottomNorthEast(),
-                new Vertex.BottomSouthEast(),
-                new Vertex.BottomSouthWest(),
-                new Vertex.BottomNorthWest());
+            new Vertex.BottomNorthEast(),
+            new Vertex.BottomSouthEast(),
+            new Vertex.BottomSouthWest(),
+            new Vertex.BottomNorthWest());
 
         params.direction.set(DOWN);
         params.textureSide.set(DOWN);

--- a/src/main/java/net/malisis/core/renderer/element/face/BottomFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/BottomFace.java
@@ -24,12 +24,8 @@ import net.malisis.core.renderer.element.Vertex;
  */
 public class BottomFace extends Face {
 
-    private static final Vertex[] DEFAULT = {
-        new Vertex.BottomNorthEast(),
-        new Vertex.BottomSouthEast(),
-        new Vertex.BottomSouthWest(),
-        new Vertex.BottomNorthWest()
-    };
+    private static final Vertex[] DEFAULT = { new Vertex.BottomNorthEast(), new Vertex.BottomSouthEast(),
+        new Vertex.BottomSouthWest(), new Vertex.BottomNorthWest() };
 
     @Override
     public void reset() {

--- a/src/main/java/net/malisis/core/renderer/element/face/BottomFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/BottomFace.java
@@ -31,6 +31,7 @@ public class BottomFace extends Face {
         new Vertex.BottomNorthWest()
     };
 
+    @Override
     public void reset() {
         for (int i = 0; i < 4; ++i) {
             this.vertexes[i].setState(DEFAULT[i]);

--- a/src/main/java/net/malisis/core/renderer/element/face/EastFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/EastFace.java
@@ -24,12 +24,25 @@ import net.malisis.core.renderer.element.Vertex;
  */
 public class EastFace extends Face {
 
+    private static final Vertex[] DEFAULT = {
+        new Vertex.TopSouthEast(),
+        new Vertex.BottomSouthEast(),
+        new Vertex.BottomNorthEast(),
+        new Vertex.TopNorthEast()
+    };
+
+    public void reset() {
+        for (int i = 0; i < 4; ++i) {
+            this.vertexes[i].setState(DEFAULT[i]);
+        }
+    }
+
     public EastFace() {
         super(
-                new Vertex.TopSouthEast(),
-                new Vertex.BottomSouthEast(),
-                new Vertex.BottomNorthEast(),
-                new Vertex.TopNorthEast());
+            new Vertex.TopSouthEast(),
+            new Vertex.BottomSouthEast(),
+            new Vertex.BottomNorthEast(),
+            new Vertex.TopNorthEast());
 
         params.direction.set(EAST);
         params.textureSide.set(EAST);

--- a/src/main/java/net/malisis/core/renderer/element/face/EastFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/EastFace.java
@@ -31,6 +31,7 @@ public class EastFace extends Face {
         new Vertex.TopNorthEast()
     };
 
+    @Override
     public void reset() {
         for (int i = 0; i < 4; ++i) {
             this.vertexes[i].setState(DEFAULT[i]);

--- a/src/main/java/net/malisis/core/renderer/element/face/EastFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/EastFace.java
@@ -24,12 +24,8 @@ import net.malisis.core.renderer.element.Vertex;
  */
 public class EastFace extends Face {
 
-    private static final Vertex[] DEFAULT = {
-        new Vertex.TopSouthEast(),
-        new Vertex.BottomSouthEast(),
-        new Vertex.BottomNorthEast(),
-        new Vertex.TopNorthEast()
-    };
+    private static final Vertex[] DEFAULT = { new Vertex.TopSouthEast(), new Vertex.BottomSouthEast(),
+        new Vertex.BottomNorthEast(), new Vertex.TopNorthEast() };
 
     @Override
     public void reset() {

--- a/src/main/java/net/malisis/core/renderer/element/face/NorthFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/NorthFace.java
@@ -24,12 +24,25 @@ import net.malisis.core.renderer.element.Vertex;
  */
 public class NorthFace extends Face {
 
+    private static final Vertex[] DEFAULT = {
+        new Vertex.TopNorthEast(),
+        new Vertex.BottomNorthEast(),
+        new Vertex.BottomNorthWest(),
+        new Vertex.TopNorthWest()
+    };
+
+    public void reset() {
+        for (int i = 0; i < 4; ++i) {
+            this.vertexes[i].setState(DEFAULT[i]);
+        }
+    }
+
     public NorthFace() {
         super(
-                new Vertex.TopNorthEast(),
-                new Vertex.BottomNorthEast(),
-                new Vertex.BottomNorthWest(),
-                new Vertex.TopNorthWest());
+            new Vertex.TopNorthEast(),
+            new Vertex.BottomNorthEast(),
+            new Vertex.BottomNorthWest(),
+            new Vertex.TopNorthWest());
 
         params.direction.set(NORTH);
         params.textureSide.set(NORTH);

--- a/src/main/java/net/malisis/core/renderer/element/face/NorthFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/NorthFace.java
@@ -31,6 +31,7 @@ public class NorthFace extends Face {
         new Vertex.TopNorthWest()
     };
 
+    @Override
     public void reset() {
         for (int i = 0; i < 4; ++i) {
             this.vertexes[i].setState(DEFAULT[i]);

--- a/src/main/java/net/malisis/core/renderer/element/face/NorthFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/NorthFace.java
@@ -24,12 +24,8 @@ import net.malisis.core.renderer.element.Vertex;
  */
 public class NorthFace extends Face {
 
-    private static final Vertex[] DEFAULT = {
-        new Vertex.TopNorthEast(),
-        new Vertex.BottomNorthEast(),
-        new Vertex.BottomNorthWest(),
-        new Vertex.TopNorthWest()
-    };
+    private static final Vertex[] DEFAULT = { new Vertex.TopNorthEast(), new Vertex.BottomNorthEast(),
+        new Vertex.BottomNorthWest(), new Vertex.TopNorthWest() };
 
     @Override
     public void reset() {

--- a/src/main/java/net/malisis/core/renderer/element/face/SouthFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/SouthFace.java
@@ -31,6 +31,7 @@ public class SouthFace extends Face {
         new Vertex.TopSouthEast()
     };
 
+    @Override
     public void reset() {
         for (int i = 0; i < 4; ++i) {
             this.vertexes[i].setState(DEFAULT[i]);

--- a/src/main/java/net/malisis/core/renderer/element/face/SouthFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/SouthFace.java
@@ -24,12 +24,8 @@ import net.malisis.core.renderer.element.Vertex;
  */
 public class SouthFace extends Face {
 
-    private static final Vertex[] DEFAULT = {
-        new Vertex.TopSouthWest(),
-        new Vertex.BottomSouthWest(),
-        new Vertex.BottomSouthEast(),
-        new Vertex.TopSouthEast()
-    };
+    private static final Vertex[] DEFAULT = { new Vertex.TopSouthWest(), new Vertex.BottomSouthWest(),
+        new Vertex.BottomSouthEast(), new Vertex.TopSouthEast() };
 
     @Override
     public void reset() {

--- a/src/main/java/net/malisis/core/renderer/element/face/SouthFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/SouthFace.java
@@ -24,12 +24,25 @@ import net.malisis.core.renderer.element.Vertex;
  */
 public class SouthFace extends Face {
 
+    private static final Vertex[] DEFAULT = {
+        new Vertex.TopSouthWest(),
+        new Vertex.BottomSouthWest(),
+        new Vertex.BottomSouthEast(),
+        new Vertex.TopSouthEast()
+    };
+
+    public void reset() {
+        for (int i = 0; i < 4; ++i) {
+            this.vertexes[i].setState(DEFAULT[i]);
+        }
+    }
+
     public SouthFace() {
         super(
-                new Vertex.TopSouthWest(),
-                new Vertex.BottomSouthWest(),
-                new Vertex.BottomSouthEast(),
-                new Vertex.TopSouthEast());
+            new Vertex.TopSouthWest(),
+            new Vertex.BottomSouthWest(),
+            new Vertex.BottomSouthEast(),
+            new Vertex.TopSouthEast());
 
         params.direction.set(SOUTH);
         params.textureSide.set(SOUTH);

--- a/src/main/java/net/malisis/core/renderer/element/face/TopFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/TopFace.java
@@ -24,12 +24,8 @@ import net.malisis.core.renderer.element.Vertex;
  */
 public class TopFace extends Face {
 
-    private static final Vertex[] DEFAULT = {
-        new Vertex.TopNorthWest(),
-        new Vertex.TopSouthWest(),
-        new Vertex.TopSouthEast(),
-        new Vertex.TopNorthEast()
-    };
+    private static final Vertex[] DEFAULT = { new Vertex.TopNorthWest(), new Vertex.TopSouthWest(),
+        new Vertex.TopSouthEast(), new Vertex.TopNorthEast() };
 
     @Override
     public void reset() {

--- a/src/main/java/net/malisis/core/renderer/element/face/TopFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/TopFace.java
@@ -31,6 +31,7 @@ public class TopFace extends Face {
         new Vertex.TopNorthEast()
     };
 
+    @Override
     public void reset() {
         for (int i = 0; i < 4; ++i) {
             this.vertexes[i].setState(DEFAULT[i]);

--- a/src/main/java/net/malisis/core/renderer/element/face/TopFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/TopFace.java
@@ -24,12 +24,25 @@ import net.malisis.core.renderer.element.Vertex;
  */
 public class TopFace extends Face {
 
+    private static final Vertex[] DEFAULT = {
+        new Vertex.TopNorthWest(),
+        new Vertex.TopSouthWest(),
+        new Vertex.TopSouthEast(),
+        new Vertex.TopNorthEast()
+    };
+
+    public void reset() {
+        for (int i = 0; i < 4; ++i) {
+            this.vertexes[i].setState(DEFAULT[i]);
+        }
+    }
+
     public TopFace() {
         super(
-                new Vertex.TopNorthWest(),
-                new Vertex.TopSouthWest(),
-                new Vertex.TopSouthEast(),
-                new Vertex.TopNorthEast());
+            new Vertex.TopNorthWest(),
+            new Vertex.TopSouthWest(),
+            new Vertex.TopSouthEast(),
+            new Vertex.TopNorthEast());
 
         params.direction.set(UP);
         params.textureSide.set(UP);

--- a/src/main/java/net/malisis/core/renderer/element/face/WestFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/WestFace.java
@@ -24,12 +24,25 @@ import net.malisis.core.renderer.element.Vertex;
  */
 public class WestFace extends Face {
 
+    private static final Vertex[] DEFAULT = {
+        new Vertex.TopNorthWest(),
+        new Vertex.BottomNorthWest(),
+        new Vertex.BottomSouthWest(),
+        new Vertex.TopSouthWest()
+    };
+
+    public void reset() {
+        for (int i = 0; i < 4; ++i) {
+            this.vertexes[i].setState(DEFAULT[i]);
+        }
+    }
+
     public WestFace() {
         super(
-                new Vertex.TopNorthWest(),
-                new Vertex.BottomNorthWest(),
-                new Vertex.BottomSouthWest(),
-                new Vertex.TopSouthWest());
+            new Vertex.TopNorthWest(),
+            new Vertex.BottomNorthWest(),
+            new Vertex.BottomSouthWest(),
+            new Vertex.TopSouthWest());
 
         params.direction.set(WEST);
         params.textureSide.set(WEST);

--- a/src/main/java/net/malisis/core/renderer/element/face/WestFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/WestFace.java
@@ -24,12 +24,8 @@ import net.malisis.core.renderer.element.Vertex;
  */
 public class WestFace extends Face {
 
-    private static final Vertex[] DEFAULT = {
-        new Vertex.TopNorthWest(),
-        new Vertex.BottomNorthWest(),
-        new Vertex.BottomSouthWest(),
-        new Vertex.TopSouthWest()
-    };
+    private static final Vertex[] DEFAULT = { new Vertex.TopNorthWest(), new Vertex.BottomNorthWest(),
+        new Vertex.BottomSouthWest(), new Vertex.TopSouthWest() };
 
     @Override
     public void reset() {

--- a/src/main/java/net/malisis/core/renderer/element/face/WestFace.java
+++ b/src/main/java/net/malisis/core/renderer/element/face/WestFace.java
@@ -31,6 +31,7 @@ public class WestFace extends Face {
         new Vertex.TopSouthWest()
     };
 
+    @Override
     public void reset() {
         for (int i = 0; i < 4; ++i) {
             this.vertexes[i].setState(DEFAULT[i]);

--- a/src/main/java/net/malisis/core/renderer/element/shape/Cube.java
+++ b/src/main/java/net/malisis/core/renderer/element/shape/Cube.java
@@ -34,4 +34,9 @@ public class Cube extends Shape {
         super(new NorthFace(), new SouthFace(), new EastFace(), new WestFace(), new TopFace(), new BottomFace());
         storeState();
     }
+
+    public void reset() {
+        for (Face f : this.faces) f.reset();
+        this.transformMatrix.identity();
+    }
 }

--- a/src/main/java/net/malisis/core/renderer/element/shape/Cube.java
+++ b/src/main/java/net/malisis/core/renderer/element/shape/Cube.java
@@ -21,7 +21,6 @@ import net.malisis.core.renderer.element.face.NorthFace;
 import net.malisis.core.renderer.element.face.SouthFace;
 import net.malisis.core.renderer.element.face.TopFace;
 import net.malisis.core.renderer.element.face.WestFace;
-import org.lwjgl.Sys;
 
 /**
  * Basic Cube {@link Shape} using predefined {@link Face faces}.

--- a/src/main/java/net/malisis/core/renderer/element/shape/Cube.java
+++ b/src/main/java/net/malisis/core/renderer/element/shape/Cube.java
@@ -48,11 +48,9 @@ public class Cube extends Shape {
         return this;
     }
 
+    @Override
     public void reset() {
-        for (Face f : this.faces) f.reset();
-        this.resetMatrix();
-        if (this.mergedVertexes != null)
-            this.mergedVertexes.clear();
+        super.reset();
         this.storeState();
     }
 }

--- a/src/main/java/net/malisis/core/renderer/element/shape/Cube.java
+++ b/src/main/java/net/malisis/core/renderer/element/shape/Cube.java
@@ -21,6 +21,7 @@ import net.malisis.core.renderer.element.face.NorthFace;
 import net.malisis.core.renderer.element.face.SouthFace;
 import net.malisis.core.renderer.element.face.TopFace;
 import net.malisis.core.renderer.element.face.WestFace;
+import org.lwjgl.Sys;
 
 /**
  * Basic Cube {@link Shape} using predefined {@link Face faces}.
@@ -35,8 +36,23 @@ public class Cube extends Shape {
         storeState();
     }
 
+    public Cube(Cube c) {
+        super(c);
+    }
+
+    public Cube copy(Cube c) {
+        for (int i = 0; i < 6; ++i) {
+            this.faces[i].copy(c.faces[i]);
+        }
+        this.copyMatrix(c);
+        return this;
+    }
+
     public void reset() {
         for (Face f : this.faces) f.reset();
-        this.transformMatrix.identity();
+        this.resetMatrix();
+        if (this.mergedVertexes != null)
+            this.mergedVertexes.clear();
+        this.storeState();
     }
 }

--- a/src/main/java/net/malisis/core/renderer/font/FontGenerator.java
+++ b/src/main/java/net/malisis/core/renderer/font/FontGenerator.java
@@ -75,10 +75,10 @@ public class FontGenerator {
                 // baseLine
                 g.setColor(Color.RED);
                 g.drawLine(
-                        x,
-                        (int) (y + cd.getAscent()),
-                        (int) (x + cd.getFullWidth(options)),
-                        (int) (y + cd.getAscent()));
+                    x,
+                    (int) (y + cd.getAscent()),
+                    (int) (x + cd.getFullWidth(options)),
+                    (int) (y + cd.getAscent()));
 
                 g.setColor(Color.MAGENTA);
                 g.drawRect(x, y, (int) (cd.getCharWidth()), (int) (cd.getCharHeight()));

--- a/src/main/java/net/malisis/core/renderer/font/Link.java
+++ b/src/main/java/net/malisis/core/renderer/font/Link.java
@@ -84,7 +84,8 @@ public class Link implements GuiYesNoCallback {
     }
 
     public void click() {
-        Minecraft.getMinecraft().displayGuiScreen(new GuiConfirmOpenLink(this, url, 0, false));
+        Minecraft.getMinecraft()
+            .displayGuiScreen(new GuiConfirmOpenLink(this, url, 0, false));
     }
 
     @Override
@@ -92,7 +93,8 @@ public class Link implements GuiYesNoCallback {
         if (result) {
             MalisisCore.message("Opening " + url);
             try {
-                Desktop.getDesktop().browse(new URI(url));
+                Desktop.getDesktop()
+                    .browse(new URI(url));
             } catch (Throwable throwable) {
                 MalisisCore.log.error("Couldn't open link", throwable);
             }
@@ -111,7 +113,8 @@ public class Link implements GuiYesNoCallback {
         int i = index;
         while (i > 0) {
             link = FontRenderOptions.getLink(str, i--);
-            if (link != null && index < link.index + link.toString().length()) return link;
+            if (link != null && index < link.index + link.toString()
+                .length()) return link;
         }
 
         return null;

--- a/src/main/java/net/malisis/core/renderer/font/MalisisFont.java
+++ b/src/main/java/net/malisis/core/renderer/font/MalisisFont.java
@@ -147,7 +147,9 @@ public class MalisisFont {
         boolean isGui = renderer instanceof GuiRenderer;
         renderer.next(GL11.GL_QUADS);
 
-        Minecraft.getMinecraft().getTextureManager().bindTexture(textureRl);
+        Minecraft.getMinecraft()
+            .getTextureManager()
+            .bindTexture(textureRl);
         GL11.glPushMatrix();
         GL11.glTranslatef(x, y + (isGui ? 0 : fro.fontScale), z);
 
@@ -157,8 +159,11 @@ public class MalisisFont {
     protected void clean(MalisisRenderer renderer, boolean isDrawing) {
         if (isDrawing) renderer.next();
         else renderer.draw();
-        if (renderer instanceof GuiRenderer) Minecraft.getMinecraft().getTextureManager()
-                .bindTexture(((GuiRenderer) renderer).getDefaultTexture().getResourceLocation());
+        if (renderer instanceof GuiRenderer) Minecraft.getMinecraft()
+            .getTextureManager()
+            .bindTexture(
+                ((GuiRenderer) renderer).getDefaultTexture()
+                    .getResourceLocation());
         GL11.glPopMatrix();
     }
 
@@ -318,8 +323,8 @@ public class MalisisFont {
 
     private boolean hasLines(String text, FontRenderOptions fro) {
         return fro.underline || fro.strikethrough
-                || text.contains(EnumChatFormatting.UNDERLINE.toString())
-                || text.contains(EnumChatFormatting.STRIKETHROUGH.toString());
+            || text.contains(EnumChatFormatting.UNDERLINE.toString())
+            || text.contains(EnumChatFormatting.STRIKETHROUGH.toString());
     }
 
     /**
@@ -389,9 +394,8 @@ public class MalisisFont {
         if (StringUtils.isEmpty(str)) return 0;
 
         str = processString(str, fro);
-        return (float) font.getStringBounds(str, frc).getWidth() / options.fontSize
-                * (fro != null ? fro.fontScale : 1)
-                * 9;
+        return (float) font.getStringBounds(str, frc)
+            .getWidth() / options.fontSize * (fro != null ? fro.fontScale : 1) * 9;
     }
 
     public float getStringWidth(String str, FontRenderOptions fro) {
@@ -608,10 +612,14 @@ public class MalisisFont {
 
         if (img == null) return;
 
-        if (textureRl != null) Minecraft.getMinecraft().getTextureManager().deleteTexture(textureRl);
+        if (textureRl != null) Minecraft.getMinecraft()
+            .getTextureManager()
+            .deleteTexture(textureRl);
 
         DynamicTexture dynTex = new DynamicTexture(img);
-        textureRl = Minecraft.getMinecraft().getTextureManager().getDynamicTextureLocation(font.getName(), dynTex);
+        textureRl = Minecraft.getMinecraft()
+            .getTextureManager()
+            .getDynamicTextureLocation(font.getName(), dynTex);
     }
 
     protected BufferedImage readTextureFile(File textureFile) {
@@ -637,10 +645,10 @@ public class MalisisFont {
                 String[] split = str.split(";");
                 CharData cd = charData[i++];
                 cd.setUVs(
-                        Float.parseFloat(split[1]),
-                        Float.parseFloat(split[2]),
-                        Float.parseFloat(split[3]),
-                        Float.parseFloat(split[4]));
+                    Float.parseFloat(split[1]),
+                    Float.parseFloat(split[2]),
+                    Float.parseFloat(split[3]),
+                    Float.parseFloat(split[4]));
             }
         } catch (IOException | NumberFormatException e) {
             MalisisCore.log.error("Failed to read font data. (Line " + i + " (" + (char) i + ")", e);
@@ -652,7 +660,12 @@ public class MalisisFont {
     // #region Font load
     public static Font load(ResourceLocation rl, FontGeneratorOptions options) {
         try {
-            return load(Minecraft.getMinecraft().getResourceManager().getResource(rl).getInputStream(), options);
+            return load(
+                Minecraft.getMinecraft()
+                    .getResourceManager()
+                    .getResource(rl)
+                    .getInputStream(),
+                options);
         } catch (IOException e) {
             MalisisCore.log.error("[MalisiFont] Couldn't load font from ResourceLocation.", e);
             return null;

--- a/src/main/java/net/malisis/core/renderer/font/MinecraftFont.java
+++ b/src/main/java/net/malisis/core/renderer/font/MinecraftFont.java
@@ -54,10 +54,12 @@ public class MinecraftFont extends MalisisFont {
     static {
         try {
             String srg = "field_78286_d";
-            if (FMLClientHandler.instance().hasOptifine()) srg = "d";
+            if (FMLClientHandler.instance()
+                .hasOptifine()) srg = "d";
             Field charWidthField = FontRenderer.class.getDeclaredField(MalisisCore.isObfEnv ? srg : "charWidth");
             charWidthField.setAccessible(true);
-            charWidthMethodHandle = MethodHandles.lookup().unreflectGetter(charWidthField);
+            charWidthMethodHandle = MethodHandles.lookup()
+                .unreflectGetter(charWidthField);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException("Failed to access a value from FontRenderer", e);
         }
@@ -79,8 +81,8 @@ public class MinecraftFont extends MalisisFont {
         try {
             if (fontRenderer == null) throw new IllegalStateException("fontRenderer not initialized");
 
-            if (FMLClientHandler.instance().hasOptifine())
-                optifineCharWidth = (float[]) charWidthMethodHandle.invokeExact(fontRenderer);
+            if (FMLClientHandler.instance()
+                .hasOptifine()) optifineCharWidth = (float[]) charWidthMethodHandle.invokeExact(fontRenderer);
             else mcCharWidth = (int[]) charWidthMethodHandle.invokeExact(fontRenderer);
 
             glyphWidth = fontRenderer.glyphWidth;
@@ -100,7 +102,9 @@ public class MinecraftFont extends MalisisFont {
         }
         if (rl != lastFontTexture) {
             renderer.next();
-            Minecraft.getMinecraft().getTextureManager().bindTexture(rl);
+            Minecraft.getMinecraft()
+                .getTextureManager()
+                .bindTexture(rl);
             lastFontTexture = rl;
         }
     }
@@ -213,7 +217,8 @@ public class MinecraftFont extends MalisisFont {
         @Override
         public float getCharWidth() {
             if (c == ' ' || c < 0 || c >= 256 || pos == -1) return 4.0F;
-            else if (FMLClientHandler.instance().hasOptifine()) return optifineCharWidth[c];
+            else if (FMLClientHandler.instance()
+                .hasOptifine()) return optifineCharWidth[c];
             else return mcCharWidth[pos];
         }
 

--- a/src/main/java/net/malisis/core/renderer/icon/ConnectedTextureIcon.java
+++ b/src/main/java/net/malisis/core/renderer/icon/ConnectedTextureIcon.java
@@ -74,30 +74,47 @@ public class ConnectedTextureIcon extends MalisisIcon {
     protected void initIcon(MalisisIcon icon, int width, int height, int x, int y, boolean rotated) {
         float f = 1F / 3F;
 
-        if (icon.getIconName().equals(getIconName())) {
-            icons[LEFT | TOP] = icon.copy().clip(0, 0, f, f);
-            icons[TOP] = icon.copy().clip(f, 0, f, f);
-            icons[RIGHT | TOP] = icon.copy().clip(2 * f, 0, f, f);
+        if (icon.getIconName()
+            .equals(getIconName())) {
+            icons[LEFT | TOP] = icon.copy()
+                .clip(0, 0, f, f);
+            icons[TOP] = icon.copy()
+                .clip(f, 0, f, f);
+            icons[RIGHT | TOP] = icon.copy()
+                .clip(2 * f, 0, f, f);
 
-            icons[LEFT] = icon.copy().clip(0, f, f, f);
-            icons[NONE] = icon.copy().clip(f, f, f, f);
-            icons[RIGHT] = icon.copy().clip(2 * f, f, f, f);
+            icons[LEFT] = icon.copy()
+                .clip(0, f, f, f);
+            icons[NONE] = icon.copy()
+                .clip(f, f, f, f);
+            icons[RIGHT] = icon.copy()
+                .clip(2 * f, f, f, f);
 
-            icons[LEFT | BOTTOM] = icon.copy().clip(0, 2 * f, f, f);
-            icons[BOTTOM] = icon.copy().clip(f, 2 * f, f, f);
-            icons[RIGHT | BOTTOM] = icon.copy().clip(2 * f, 2 * f, f, f);
+            icons[LEFT | BOTTOM] = icon.copy()
+                .clip(0, 2 * f, f, f);
+            icons[BOTTOM] = icon.copy()
+                .clip(f, 2 * f, f, f);
+            icons[RIGHT | BOTTOM] = icon.copy()
+                .clip(2 * f, 2 * f, f, f);
         } else {
-            icons[LEFT | TOP | BOTTOM] = icon.copy().clip(0, 0, f, f);
-            icons[TOP | BOTTOM] = icon.copy().clip(f, 0, f, f);
-            icons[LEFT | RIGHT | TOP] = icon.copy().clip(2 * f, 0, f, f);
+            icons[LEFT | TOP | BOTTOM] = icon.copy()
+                .clip(0, 0, f, f);
+            icons[TOP | BOTTOM] = icon.copy()
+                .clip(f, 0, f, f);
+            icons[LEFT | RIGHT | TOP] = icon.copy()
+                .clip(2 * f, 0, f, f);
 
-            icons[LEFT | RIGHT] = icon.copy().clip(0, f, f, f);
-            icons[FULL] = icon.copy().clip(f, f, f, f);
+            icons[LEFT | RIGHT] = icon.copy()
+                .clip(0, f, f, f);
+            icons[FULL] = icon.copy()
+                .clip(f, f, f, f);
             // icons[LEFT | RIGHT] = icon.copy().clip(2 * f, f, f, f);
 
-            icons[LEFT | RIGHT | BOTTOM] = icon.copy().clip(0, 2 * f, f, f);
+            icons[LEFT | RIGHT | BOTTOM] = icon.copy()
+                .clip(0, 2 * f, f, f);
             // icons[TOP | BOTTOM] = icon.copy().clip(f, 2 * f, f, f);
-            icons[RIGHT | TOP | BOTTOM] = icon.copy().clip(2 * f, 2 * f, f, f);
+            icons[RIGHT | TOP | BOTTOM] = icon.copy()
+                .clip(2 * f, 2 * f, f, f);
         }
     }
 
@@ -142,10 +159,9 @@ public class ConnectedTextureIcon extends MalisisIcon {
         int connection = 0;
         for (int i = 0; i < 4; i++) {
             if (world.getBlock(
-                    x + sides[dir.ordinal()][i].offsetX,
-                    y + sides[dir.ordinal()][i].offsetY,
-                    z + sides[dir.ordinal()][i].offsetZ) == block)
-                connection |= (1 << i);
+                x + sides[dir.ordinal()][i].offsetX,
+                y + sides[dir.ordinal()][i].offsetY,
+                z + sides[dir.ordinal()][i].offsetZ) == block) connection |= (1 << i);
         }
         return ~connection & 15;
     }

--- a/src/main/java/net/malisis/core/renderer/model/MalisisModel.java
+++ b/src/main/java/net/malisis/core/renderer/model/MalisisModel.java
@@ -33,7 +33,7 @@ import net.minecraft.util.ResourceLocation;
  * @author Ordinastie
  */
 public class MalisisModel
-        implements ITransformable.Translate, ITransformable.Rotate, ITransformable.Scale, Iterable<Shape> {
+    implements ITransformable.Translate, ITransformable.Rotate, ITransformable.Scale, Iterable<Shape> {
 
     /** Shapes building this {@link MalisisModel}. */
     protected Map<String, Shape> shapes = new HashMap<>();
@@ -66,7 +66,8 @@ public class MalisisModel
         if (resource == null) return;
 
         IModelLoader loader = null;
-        if (resource.getResourcePath().endsWith(".obj")) loader = new ObjFileImporter(resource);
+        if (resource.getResourcePath()
+            .endsWith(".obj")) loader = new ObjFileImporter(resource);
 
         if (loader != null) load(loader);
         else MalisisCore.log.error("[MalisisModel] No loader determined for {}.", resource.getResourcePath());
@@ -198,6 +199,7 @@ public class MalisisModel
 
     @Override
     public Iterator<Shape> iterator() {
-        return shapes.values().iterator();
+        return shapes.values()
+            .iterator();
     }
 }

--- a/src/main/java/net/malisis/core/renderer/model/MalisisModel.java
+++ b/src/main/java/net/malisis/core/renderer/model/MalisisModel.java
@@ -38,6 +38,10 @@ public class MalisisModel
     /** Shapes building this {@link MalisisModel}. */
     protected Map<String, Shape> shapes = new HashMap<>();
 
+    public void reset() {
+        this.shapes.clear();
+    }
+
     /**
      * Instantiates a new empty {@link MalisisModel}.<br>
      * Allows {@link Shape shapes} to be added manually to the model.

--- a/src/main/java/net/malisis/core/renderer/model/loader/ObjFileImporter.java
+++ b/src/main/java/net/malisis/core/renderer/model/loader/ObjFileImporter.java
@@ -113,11 +113,13 @@ public class ObjFileImporter implements IModelLoader {
      */
     public void load(ResourceLocation resourceLocation) {
         try {
-            IResource res = Minecraft.getMinecraft().getResourceManager().getResource(resourceLocation);
+            IResource res = Minecraft.getMinecraft()
+                .getResourceManager()
+                .getResource(resourceLocation);
             load(res.getInputStream());
         } catch (IOException e) {
             MalisisCore.log
-                    .error("[ObjFileImporter] An error happened while reading the file : {}", resourceLocation, e);
+                .error("[ObjFileImporter] An error happened while reading the file : {}", resourceLocation, e);
         }
     }
 
@@ -131,7 +133,8 @@ public class ObjFileImporter implements IModelLoader {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
             while ((currentLine = reader.readLine()) != null) {
                 lineNumber++;
-                currentLine = currentLine.replaceAll("\\s+", " ").trim();
+                currentLine = currentLine.replaceAll("\\s+", " ")
+                    .trim();
                 matcher = linePattern.matcher(currentLine);
 
                 if (matcher.matches()) {
@@ -158,15 +161,15 @@ public class ObjFileImporter implements IModelLoader {
 
                         default:
                             MalisisCore.log.debug(
-                                    "[ObjFileImporter] Skipped type {} at line {} : {}",
-                                    type,
-                                    lineNumber,
-                                    currentLine);
+                                "[ObjFileImporter] Skipped type {} at line {} : {}",
+                                type,
+                                lineNumber,
+                                currentLine);
                             break;
                     }
                 } else {
                     MalisisCore.log
-                            .debug("[ObjFileImporter] Skipped non-matching line {} : {}", lineNumber, currentLine);
+                        .debug("[ObjFileImporter] Skipped non-matching line {} : {}", lineNumber, currentLine);
                 }
             }
 
@@ -188,10 +191,10 @@ public class ObjFileImporter implements IModelLoader {
         float z = 0;
         if (coords.length != 3) {
             MalisisCore.log.error(
-                    "[ObjFileImporter] Wrong coordinates number {} at line {} : {}",
-                    coords.length,
-                    lineNumber,
-                    currentLine);
+                "[ObjFileImporter] Wrong coordinates number {} at line {} : {}",
+                coords.length,
+                lineNumber,
+                currentLine);
         } else {
             x = Float.parseFloat(coords[0]);
             y = Float.parseFloat(coords[1]);
@@ -212,10 +215,10 @@ public class ObjFileImporter implements IModelLoader {
         float v = 0;
         if (coords.length != 2) {
             MalisisCore.log.error(
-                    "[ObjFileImporter] Wrong UV coordinates number {} at line {} : {}",
-                    coords.length,
-                    lineNumber,
-                    currentLine);
+                "[ObjFileImporter] Wrong UV coordinates number {} at line {} : {}",
+                coords.length,
+                lineNumber,
+                currentLine);
         } else {
             u = Float.parseFloat(coords[0]);
             v = 1 - Float.parseFloat(coords[1]);
@@ -236,10 +239,10 @@ public class ObjFileImporter implements IModelLoader {
         float z = 0;
         if (coords.length != 3) {
             MalisisCore.log.error(
-                    "[ObjFileImporter] Wrong Normal coordinates number {} at line {} : {}",
-                    coords.length,
-                    lineNumber,
-                    currentLine);
+                "[ObjFileImporter] Wrong Normal coordinates number {} at line {} : {}",
+                coords.length,
+                lineNumber,
+                currentLine);
         } else {
             x = Float.parseFloat(coords[0]);
             y = Float.parseFloat(coords[1]);
@@ -293,10 +296,10 @@ public class ObjFileImporter implements IModelLoader {
                 }
             } else {
                 MalisisCore.log.error(
-                        "[ObjFileImporter] Wrong vertex reference {} for face at line {} :\n{}",
-                        v,
-                        lineNumber,
-                        currentLine);
+                    "[ObjFileImporter] Wrong vertex reference {} for face at line {} :\n{}",
+                    v,
+                    lineNumber,
+                    currentLine);
             }
         }
 

--- a/src/main/java/net/malisis/core/tileentity/TileEntitySidedInventory.java
+++ b/src/main/java/net/malisis/core/tileentity/TileEntitySidedInventory.java
@@ -55,7 +55,8 @@ public abstract class TileEntitySidedInventory extends TileEntity implements IIn
 
     @Override
     public MalisisInventory[] getInventories(Object... data) {
-        return inventories.values().toArray(new MalisisInventory[0]);
+        return inventories.values()
+            .toArray(new MalisisInventory[0]);
     }
 
     @Override

--- a/src/main/java/net/malisis/core/util/AABBUtils.java
+++ b/src/main/java/net/malisis/core/util/AABBUtils.java
@@ -163,12 +163,12 @@ public class AABBUtils {
 
     public static AxisAlignedBB readFromNBT(NBTTagCompound tag, AxisAlignedBB aabb) {
         return aabb.setBounds(
-                tag.getDouble("minX"),
-                tag.getDouble("minY"),
-                tag.getDouble("minZ"),
-                tag.getDouble("maxX"),
-                tag.getDouble("maxY"),
-                tag.getDouble("maxZ"));
+            tag.getDouble("minX"),
+            tag.getDouble("minY"),
+            tag.getDouble("minZ"),
+            tag.getDouble("maxX"),
+            tag.getDouble("maxY"),
+            tag.getDouble("maxZ"));
     }
 
     public static void writeToNBT(NBTTagCompound tag, AxisAlignedBB aabb) {
@@ -189,12 +189,12 @@ public class AABBUtils {
      */
     public static AxisAlignedBB combine(AxisAlignedBB[] aabbs) {
         AxisAlignedBB ret = AxisAlignedBB.getBoundingBox(
-                Double.MAX_VALUE,
-                Double.MAX_VALUE,
-                Double.MAX_VALUE,
-                Double.MIN_VALUE,
-                Double.MAX_VALUE,
-                Double.MAX_VALUE);
+            Double.MAX_VALUE,
+            Double.MAX_VALUE,
+            Double.MAX_VALUE,
+            Double.MIN_VALUE,
+            Double.MAX_VALUE,
+            Double.MAX_VALUE);
 
         for (AxisAlignedBB aabb : aabbs) {
             ret.minX = Math.min(aabb.minX, ret.minX);
@@ -278,7 +278,7 @@ public class AABBUtils {
      * @return the collision bounding boxes
      */
     public static AxisAlignedBB[] getCollisionBoundingBoxes(World world, Block block, int x, int y, int z,
-            boolean offset) {
+        boolean offset) {
         return getCollisionBoundingBoxes(world, new BlockState(x, y, z, block), offset);
     }
 
@@ -303,10 +303,10 @@ public class AABBUtils {
     public static AxisAlignedBB[] getCollisionBoundingBoxes(World world, BlockState state, boolean offset) {
         AxisAlignedBB[] aabbs = new AxisAlignedBB[0];
         if (state.getBlock() instanceof MalisisBlock) aabbs = ((MalisisBlock) state.getBlock())
-                .getBoundingBox(world, state.getX(), state.getY(), state.getZ(), BoundingBoxType.CHUNKCOLLISION);
+            .getBoundingBox(world, state.getX(), state.getY(), state.getZ(), BoundingBoxType.CHUNKCOLLISION);
         else {
             AxisAlignedBB aabb = state.getBlock()
-                    .getCollisionBoundingBoxFromPool(world, state.getX(), state.getY(), state.getZ());
+                .getCollisionBoundingBoxFromPool(world, state.getX(), state.getY(), state.getZ());
             if (aabb != null) aabbs = new AxisAlignedBB[] { aabb.offset(-state.getX(), -state.getY(), -state.getZ()) };
         }
 

--- a/src/main/java/net/malisis/core/util/BlockPos.java
+++ b/src/main/java/net/malisis/core/util/BlockPos.java
@@ -201,9 +201,9 @@ public class BlockPos {
      */
     public BlockPos offset(ForgeDirection facing, int n) {
         return new BlockPos(
-                this.getX() + facing.offsetX * n,
-                this.getY() + facing.offsetY * n,
-                this.getZ() + facing.offsetZ * n);
+            this.getX() + facing.offsetX * n,
+            this.getY() + facing.offsetY * n,
+            this.getZ() + facing.offsetZ * n);
     }
 
     public BlockPos rotate(int rotation) {
@@ -275,23 +275,23 @@ public class BlockPos {
 
     public static BlockPos minOf(BlockPos p1, BlockPos p2) {
         return new BlockPos(
-                Math.min(p1.getX(), p2.getX()),
-                Math.min(p1.getY(), p2.getY()),
-                Math.min(p1.getZ(), p2.getZ()));
+            Math.min(p1.getX(), p2.getX()),
+            Math.min(p1.getY(), p2.getY()),
+            Math.min(p1.getZ(), p2.getZ()));
     }
 
     public static BlockPos maxOf(BlockPos p1, BlockPos p2) {
         return new BlockPos(
-                Math.max(p1.getX(), p2.getX()),
-                Math.max(p1.getY(), p2.getY()),
-                Math.max(p1.getZ(), p2.getZ()));
+            Math.max(p1.getX(), p2.getX()),
+            Math.max(p1.getY(), p2.getY()),
+            Math.max(p1.getZ(), p2.getZ()));
     }
 
     public static Iterable<BlockPos> getAllInBox(AxisAlignedBB aabb) {
         AABBUtils.fix(aabb);
         return getAllInBox(
-                new BlockPos(aabb.minX, aabb.minY, aabb.minZ),
-                new BlockPos(Math.ceil(aabb.maxX) - 1, Math.ceil(aabb.maxY) - 1, Math.ceil(aabb.maxZ) - 1));
+            new BlockPos(aabb.minX, aabb.minY, aabb.minZ),
+            new BlockPos(Math.ceil(aabb.maxX) - 1, Math.ceil(aabb.maxY) - 1, Math.ceil(aabb.maxZ) - 1));
     }
 
     /**

--- a/src/main/java/net/malisis/core/util/BlockState.java
+++ b/src/main/java/net/malisis/core/util/BlockState.java
@@ -70,9 +70,9 @@ public class BlockState {
 
     public BlockState(IBlockAccess world, BlockPos pos) {
         this(
-                pos,
-                world.getBlock(pos.getX(), pos.getY(), pos.getZ()),
-                world.getBlockMetadata(pos.getX(), pos.getY(), pos.getZ()));
+            pos,
+            world.getBlock(pos.getX(), pos.getY(), pos.getZ()),
+            world.getBlockMetadata(pos.getX(), pos.getY(), pos.getZ()));
     }
 
     public BlockState(IBlockAccess world, int x, int y, int z) {
@@ -125,7 +125,7 @@ public class BlockState {
 
     public void rotateInWorld(World world, int rotation) {
         ForgeDirection[] dirs = new ForgeDirection[] { ForgeDirection.NORTH, ForgeDirection.EAST, ForgeDirection.SOUTH,
-                ForgeDirection.WEST };
+            ForgeDirection.WEST };
         block.rotateBlock(world, getX(), getY(), getZ(), dirs[rotation / 90]);
     }
 
@@ -146,9 +146,9 @@ public class BlockState {
     }
 
     public static Iterable<BlockState> getAllInBox(IBlockAccess world, BlockPos from, BlockPos to, Block block,
-            boolean skipAir) {
+        boolean skipAir) {
         FluentIterable<BlockState> it = FluentIterable.from(new BlockIterator(from, to).asIterable())
-                .transform(toBlockState.set(world));
+            .transform(toBlockState.set(world));
         if (block != null || skipAir) it.filter(blockFilter.set(block, skipAir));
 
         return it;
@@ -165,8 +165,11 @@ public class BlockState {
     @Override
     public String toString() {
         return "[" + pos
-                + "] "
-                + (block != null ? block.getUnlocalizedName().substring(5) + " (" + metadata + ")" : "");
+            + "] "
+            + (block != null ? block.getUnlocalizedName()
+                .substring(5) + " ("
+                + metadata
+                + ")" : "");
     }
 
     public static BlockState fromNBT(NBTTagCompound nbt) {
@@ -192,7 +195,10 @@ public class BlockState {
     public static NBTTagCompound toNBT(NBTTagCompound nbt, BlockState state, String blockName, String metadataName) {
         if (state == null) return nbt;
 
-        nbt.setString(blockName, Block.blockRegistry.getNameForObject(state.getBlock()).toString());
+        nbt.setString(
+            blockName,
+            Block.blockRegistry.getNameForObject(state.getBlock())
+                .toString());
         nbt.setInteger(metadataName, state.getMetadata());
         return nbt;
     }

--- a/src/main/java/net/malisis/core/util/EntityUtils.java
+++ b/src/main/java/net/malisis/core/util/EntityUtils.java
@@ -41,7 +41,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 public class EntityUtils {
 
     private static ForgeDirection[] facings = new ForgeDirection[] { ForgeDirection.NORTH, ForgeDirection.EAST,
-            ForgeDirection.SOUTH, ForgeDirection.WEST, ForgeDirection.UP, ForgeDirection.DOWN, ForgeDirection.UNKNOWN };
+        ForgeDirection.SOUTH, ForgeDirection.WEST, ForgeDirection.UP, ForgeDirection.DOWN, ForgeDirection.UNKNOWN };
 
     /**
      * Eject a new item corresponding to the {@link ItemStack}.
@@ -73,9 +73,11 @@ public class EntityUtils {
      * @return the player
      */
     public static EntityPlayerMP findPlayerFromUUID(UUID uuid) {
-        List<EntityPlayerMP> listPlayers = MinecraftServer.getServer().getConfigurationManager().playerEntityList;
+        List<EntityPlayerMP> listPlayers = MinecraftServer.getServer()
+            .getConfigurationManager().playerEntityList;
 
-        for (EntityPlayerMP player : listPlayers) if (player.getUniqueID().equals(uuid)) return player;
+        for (EntityPlayerMP player : listPlayers) if (player.getUniqueID()
+            .equals(uuid)) return player;
 
         return null;
     }
@@ -115,7 +117,8 @@ public class EntityUtils {
 
     public static boolean isEquipped(EntityPlayer player, Item item) {
         return player != null && player.getCurrentEquippedItem() != null
-                && player.getCurrentEquippedItem().getItem() == item;
+            && player.getCurrentEquippedItem()
+                .getItem() == item;
     }
 
     public static boolean isEquipped(EntityPlayer player, ItemStack itemStack) {
@@ -128,7 +131,8 @@ public class EntityUtils {
 
     public static List<EntityPlayerMP> getPlayersWatchingChunk(WorldServer world, int x, int z) {
         try {
-            PlayerManager.PlayerInstance playerInstance = world.getPlayerManager().getOrCreateChunkWatcher(x, z, false);
+            PlayerManager.PlayerInstance playerInstance = world.getPlayerManager()
+                .getOrCreateChunkWatcher(x, z, false);
             if (playerInstance == null) return new ArrayList<>();
             return playerInstance.playersWatchingChunk;
         } catch (Throwable e) {

--- a/src/main/java/net/malisis/core/util/ItemUtils.java
+++ b/src/main/java/net/malisis/core/util/ItemUtils.java
@@ -185,9 +185,9 @@ public class ItemUtils {
      */
     public static boolean areItemStacksStackable(ItemStack stack1, ItemStack stack2) {
         return !(stack1 == null || stack2 == null) && stack1.isStackable()
-                && stack1.getItem() == stack2.getItem()
-                && (!stack2.getHasSubtypes() || stack2.getItemDamage() == stack1.getItemDamage())
-                && ItemStack.areItemStackTagsEqual(stack2, stack1);
+            && stack1.getItem() == stack2.getItem()
+            && (!stack2.getHasSubtypes() || stack2.getItemDamage() == stack1.getItemDamage())
+            && ItemStack.areItemStackTagsEqual(stack2, stack1);
     }
 
     public static BlockState getStateFromItemStack(ItemStack itemStack) {
@@ -196,13 +196,20 @@ public class ItemUtils {
         Block block = Block.getBlockFromItem(itemStack.getItem());
         if (block == null) return null;
 
-        return new BlockState(block, itemStack.getItem().getMetadata(itemStack.getItemDamage()));
+        return new BlockState(
+            block,
+            itemStack.getItem()
+                .getMetadata(itemStack.getItemDamage()));
     }
 
     public static ItemStack getItemStackFromState(BlockState state) {
         if (state == null) return null;
         Item item = Item.getItemFromBlock(state.getBlock());
         if (item == null) return null;
-        return new ItemStack(item, 1, state.getBlock().damageDropped(state.getMetadata()));
+        return new ItemStack(
+            item,
+            1,
+            state.getBlock()
+                .damageDropped(state.getMetadata()));
     }
 }

--- a/src/main/java/net/malisis/core/util/MultiBlock.java
+++ b/src/main/java/net/malisis/core/util/MultiBlock.java
@@ -170,12 +170,12 @@ public class MultiBlock {
         if (this.aabb == null) return null;
 
         AxisAlignedBB aabb = AxisAlignedBB.getBoundingBox(
-                this.aabb.minX,
-                this.aabb.minY,
-                this.aabb.minZ,
-                this.aabb.maxX,
-                this.aabb.maxY,
-                this.aabb.maxZ);
+            this.aabb.minX,
+            this.aabb.minY,
+            this.aabb.minZ,
+            this.aabb.maxX,
+            this.aabb.maxY,
+            this.aabb.maxZ);
 
         if (direction != null) {
             if (direction == ForgeDirection.EAST || direction == ForgeDirection.WEST)
@@ -246,11 +246,8 @@ public class MultiBlock {
     public boolean placeBlocks(boolean placeOrigin) {
         if (placeOrigin) {
             if (getBlock() == null) {
-                MalisisCore.log.error(
-                        "[MultiBlock] Tried to set multiblock origin at {}, {}, {}, but no block is set.",
-                        x,
-                        y,
-                        z);
+                MalisisCore.log
+                    .error("[MultiBlock] Tried to set multiblock origin at {}, {}, {}, but no block is set.", x, y, z);
                 return false;
             }
             if (getBlock().canPlaceBlockAt(world, x, y, z)) world.setBlock(x, y, z, getBlock(), 0, 3);
@@ -272,10 +269,10 @@ public class MultiBlock {
         IProvider te = TileEntityUtils.getTileEntity(IProvider.class, world, x, y, z);
         if (te == null) {
             MalisisCore.log.error(
-                    "[MultiBlock] Tried to set multiblock in provider, but no IProvider found at {}, {}, {}",
-                    x,
-                    y,
-                    z);
+                "[MultiBlock] Tried to set multiblock in provider, but no IProvider found at {}, {}, {}",
+                x,
+                y,
+                z);
             return false;
         }
         te.setMultiBlock(this);
@@ -402,7 +399,7 @@ public class MultiBlock {
     }
 
     public static <T extends TileEntity & IProvider> T getOriginProvider(Class<T> providerClass, IBlockAccess world,
-            int x, int y, int z) {
+        int x, int y, int z) {
         return getOriginProvider(TileEntityUtils.getTileEntity(providerClass, world, x, y, z));
     }
 
@@ -413,10 +410,12 @@ public class MultiBlock {
         if (mb == null) return null;
         if (provider.xCoord == mb.x && provider.yCoord == mb.y && provider.zCoord == mb.z) return provider;
 
-        TileEntity te = provider.getWorldObj().getTileEntity(mb.x, mb.y, mb.z);
+        TileEntity te = provider.getWorldObj()
+            .getTileEntity(mb.x, mb.y, mb.z);
         if (te == null || !(te instanceof IProvider)) return null;
 
-        if (provider.getClass().isAssignableFrom(te.getClass())) return (T) te;
+        if (provider.getClass()
+            .isAssignableFrom(te.getClass())) return (T) te;
 
         return null;
     }

--- a/src/main/java/net/malisis/core/util/Ray.java
+++ b/src/main/java/net/malisis/core/util/Ray.java
@@ -175,9 +175,9 @@ public class Ray {
 
     private boolean isPointInsideAABB(Vector3d point, AxisAlignedBB aabb) {
         return point.x >= aabb.minX && point.x <= aabb.maxX
-                && point.y >= aabb.minY
-                && point.y <= aabb.maxY
-                && point.z >= aabb.minZ
-                && point.z <= aabb.maxZ;
+            && point.y >= aabb.minY
+            && point.y <= aabb.maxY
+            && point.z >= aabb.minZ
+            && point.z <= aabb.maxZ;
     }
 }

--- a/src/main/java/net/malisis/core/util/RaytraceBlock.java
+++ b/src/main/java/net/malisis/core/util/RaytraceBlock.java
@@ -173,7 +173,14 @@ public class RaytraceBlock {
         Pair<ForgeDirection, Point> closest = getClosest(points);
         if (closest == null) return null;
 
-        return new MovingObjectPosition(x, y, z, closest.getLeft().ordinal(), closest.getRight().toVec3());
+        return new MovingObjectPosition(
+            x,
+            y,
+            z,
+            closest.getLeft()
+                .ordinal(),
+            closest.getRight()
+                .toVec3());
     }
 
     /**

--- a/src/main/java/net/malisis/core/util/RenderHelper.java
+++ b/src/main/java/net/malisis/core/util/RenderHelper.java
@@ -40,7 +40,10 @@ public class RenderHelper {
     }
 
     public static void bindTexture(ResourceLocation path) {
-        FMLClientHandler.instance().getClient().getTextureManager().bindTexture(path);
+        FMLClientHandler.instance()
+            .getClient()
+            .getTextureManager()
+            .bindTexture(path);
     }
 
     public static int getColorFromRGB(int r, int g, int b) {
@@ -70,18 +73,19 @@ public class RenderHelper {
     }
 
     public static Minecraft getMC() {
-        return FMLClientHandler.instance().getClient();
+        return FMLClientHandler.instance()
+            .getClient();
     }
 
     public static void drawString(String text, int x, int y, int z, int canvasWidth, int canvasHeight, int color,
-            boolean drawShadow) {
+        boolean drawShadow) {
         drawString(
-                text,
-                x + (canvasWidth - getStringWidth(text)) / 2,
-                y + (canvasHeight - getMC().fontRenderer.FONT_HEIGHT) / 2,
-                z,
-                color,
-                drawShadow);
+            text,
+            x + (canvasWidth - getStringWidth(text)) / 2,
+            y + (canvasHeight - getMC().fontRenderer.FONT_HEIGHT) / 2,
+            z,
+            color,
+            drawShadow);
     }
 
     public static void drawString(String text, int x, int y, int z, int color, boolean drawShadow) {
@@ -106,7 +110,7 @@ public class RenderHelper {
     }
 
     public static void drawLine(int color, float alpha, int startX, int startY, int endX, int endY, float width,
-            int zLevel) {
+        int zLevel) {
         Color rgb = RenderHelper.getRGBFromColor(color);
         rgb.setAlpha((int) (alpha * 255));
         drawLine(rgb, startX, startY, endX, endY, width, zLevel);
@@ -122,10 +126,10 @@ public class RenderHelper {
         glEnable(GL11.GL_BLEND);
         glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         glColor4f(
-                multiplier * color.getRed(),
-                multiplier * color.getGreen(),
-                multiplier * color.getBlue(),
-                multiplier * color.getAlpha());
+            multiplier * color.getRed(),
+            multiplier * color.getGreen(),
+            multiplier * color.getBlue(),
+            multiplier * color.getAlpha());
         glLineWidth(width);
         glBegin(GL11.GL_LINES);
         glVertex3f(startX, startY, zLevel);
@@ -155,12 +159,12 @@ public class RenderHelper {
     }
 
     public static void drawRectangle(ResourceLocation texture, int x, int y, int z, int width, int height, int u,
-            int v) {
+        int v) {
         drawRectangle(texture, x, y, z, width, height, u, v, 256, 256);
     }
 
     public static void drawRectangle(ResourceLocation texture, int x, int y, int z, int width, int height, int u, int v,
-            int textureWidth, int textureHeight) {
+        int textureWidth, int textureHeight) {
         bindTexture(texture);
         drawRectangle(x, y, z, width, height, u, v, textureWidth, textureHeight);
     }
@@ -170,17 +174,17 @@ public class RenderHelper {
     }
 
     public static void drawRectangle(int x, int y, int z, int width, int height, int u, int v, int textureWidth,
-            int textureHeight) {
+        int textureHeight) {
         drawQuad(
-                x,
-                y,
-                z,
-                width,
-                height,
-                (float) u / textureWidth,
-                (float) v / textureHeight,
-                (float) (u + width) / textureWidth,
-                (float) (v + height) / textureHeight);
+            x,
+            y,
+            z,
+            width,
+            height,
+            (float) u / textureWidth,
+            (float) v / textureHeight,
+            (float) (u + width) / textureWidth,
+            (float) (v + height) / textureHeight);
     }
 
     public static void drawQuad(int x, int y, int z, int width, int height, float u, float v, float uMax, float vMax) {
@@ -197,33 +201,33 @@ public class RenderHelper {
     }
 
     public static void drawRectangleRepeated(ResourceLocation texture, int x, int y, int z, int width, int height,
-            float u, float v, float uMax, float vMax, int tileWidth, int tileHeight) {
+        float u, float v, float uMax, float vMax, int tileWidth, int tileHeight) {
         RenderHelper.bindTexture(texture);
         drawRectangleRepeated(x, y, z, width, height, u, v, uMax, vMax, tileWidth, tileHeight);
     }
 
     public static void drawRectangleRepeated(int x, int y, int z, int width, int height, float u, float v, float uMax,
-            float vMax, int tileWidth, int tileHeight) {
+        float vMax, int tileWidth, int tileHeight) {
         loadShaders();
         shaders.activate();
         shaders.setUniform1i("tex", 0);
         shaders.setUniform2f("iconOffset", u, v);
         shaders.setUniform2f("iconSize", uMax - u, vMax - v);
         drawQuad(
-                x,
-                y,
-                z,
-                width,
-                height,
-                0,
-                0,
-                (float) getScaledWidth(width) / tileWidth,
-                (float) getScaledHeight(height) / tileHeight);
+            x,
+            y,
+            z,
+            width,
+            height,
+            0,
+            0,
+            (float) getScaledWidth(width) / tileWidth,
+            (float) getScaledHeight(height) / tileHeight);
         shaders.deactivate();
     }
 
     public static void drawRectangleXRepeated(int x, int y, int z, int width, int height, float u, float v, float uMax,
-            float vMax, int tileWidth) {
+        float vMax, int tileWidth) {
         loadShaders();
         shaders.activate();
         shaders.setUniform1i("tex", 0);
@@ -234,7 +238,7 @@ public class RenderHelper {
     }
 
     public static void drawRectangleYRepeated(int x, int y, int z, int width, int height, float u, float v, float uMax,
-            float vMax, int tileHeight) {
+        float vMax, int tileHeight) {
         loadShaders();
         shaders.activate();
         shaders.setUniform1i("tex", 0);
@@ -251,10 +255,10 @@ public class RenderHelper {
     private static ShaderSystem shaders;
 
     private static final String REPEAT_SHADER = "#version 120\n"
-            + "uniform sampler2D tex; uniform vec2 iconOffset; uniform vec2 iconSize;\n"
-            + "void main() {\n"
-            + "gl_FragColor = texture2D(tex, iconOffset + fract(gl_TexCoord[0].st) * iconSize) * gl_Color;\n"
-            + "}";
+        + "uniform sampler2D tex; uniform vec2 iconOffset; uniform vec2 iconSize;\n"
+        + "void main() {\n"
+        + "gl_FragColor = texture2D(tex, iconOffset + fract(gl_TexCoord[0].st) * iconSize) * gl_Color;\n"
+        + "}";
 
     public static void loadShaders() {
         if (shaders == null) {
@@ -265,9 +269,9 @@ public class RenderHelper {
 
     public static ScaledResolution getScaledResolution() {
         return new ScaledResolution(
-                Minecraft.getMinecraft(),
-                Minecraft.getMinecraft().displayWidth,
-                Minecraft.getMinecraft().displayHeight);
+            Minecraft.getMinecraft(),
+            Minecraft.getMinecraft().displayWidth,
+            Minecraft.getMinecraft().displayHeight);
     }
 
     public static int getScaledWidth(int width) {
@@ -289,7 +293,7 @@ public class RenderHelper {
         }
 
         while (scaleFactor < k && mc.displayWidth / (scaleFactor + 1) >= 320
-                && mc.displayHeight / (scaleFactor + 1) >= 240) {
+            && mc.displayHeight / (scaleFactor + 1) >= 240) {
             ++scaleFactor;
         }
         return scaleFactor;

--- a/src/main/java/net/malisis/core/util/bbcode/BBCodeParser.java
+++ b/src/main/java/net/malisis/core/util/bbcode/BBCodeParser.java
@@ -67,7 +67,8 @@ public class BBCodeParser extends Parser<BBNode> {
             if (match(OpenCar)) {
                 close = match(Div);
                 if (match(Identifier, c)) {
-                    switch (c.toString().toLowerCase()) {
+                    switch (c.toString()
+                        .toLowerCase()) {
                         case "b":
                         case "i":
                         case "u":
@@ -118,7 +119,8 @@ public class BBCodeParser extends Parser<BBNode> {
 
     private void addText() {
         if (StringUtils.isEmpty(textNode.getText())) return;
-        charIndex += textNode.getText().length();
+        charIndex += textNode.getText()
+            .length();
         currentNode.insert(textNode);
         textNode = new BBTextNode("");
         textNode.setIndex(charIndex);

--- a/src/main/java/net/malisis/core/util/bbcode/BBString.java
+++ b/src/main/java/net/malisis/core/util/bbcode/BBString.java
@@ -125,7 +125,8 @@ public class BBString {
         int shift = 0;
         for (BBTextNode tn : textNodes) {
             tn.shiftIndex(shift);
-            int amount = -tn.delete(start, end).length();
+            int amount = -tn.delete(start, end)
+                .length();
             shift += amount;
         }
 

--- a/src/main/java/net/malisis/core/util/bbcode/gui/BBCodeEditor.java
+++ b/src/main/java/net/malisis/core/util/bbcode/gui/BBCodeEditor.java
@@ -109,7 +109,8 @@ public class BBCodeEditor extends UIContainer<BBCodeEditor> {
     }
 
     public String getRawText() {
-        return bbTexfield.getBBText().getRawText();
+        return bbTexfield.getBBText()
+            .getRawText();
     }
 
     public BBString getBBText() {
@@ -117,7 +118,8 @@ public class BBCodeEditor extends UIContainer<BBCodeEditor> {
     }
 
     public String getBBFormattedTex() {
-        return bbTexfield.getBBText().getBBString();
+        return bbTexfield.getBBText()
+            .getBBString();
     }
 
     public boolean isWysiwyg() {
@@ -160,18 +162,39 @@ public class BBCodeEditor extends UIContainer<BBCodeEditor> {
 
     protected void createButtons(MalisisGui gui) {
         int s = 10;
-        btnBold = new UIButton(gui, "B").setAutoSize(false).setSize(s, s).setTooltip("Bold").register(this);
-        btnItalic = new UIButton(gui, "I").setAutoSize(false).setSize(s, s).setTooltip("Italic").register(this);
-        btnUnderline = new UIButton(gui, "U").setAutoSize(false).setSize(s, s).setTooltip("Underline").register(this);
-        btnStrikethrough = new UIButton(gui, "S").setAutoSize(false).setSize(s, s).setTooltip("Strikethrough")
-                .register(this);
+        btnBold = new UIButton(gui, "B").setAutoSize(false)
+            .setSize(s, s)
+            .setTooltip("Bold")
+            .register(this);
+        btnItalic = new UIButton(gui, "I").setAutoSize(false)
+            .setSize(s, s)
+            .setTooltip("Italic")
+            .register(this);
+        btnUnderline = new UIButton(gui, "U").setAutoSize(false)
+            .setSize(s, s)
+            .setTooltip("Underline")
+            .register(this);
+        btnStrikethrough = new UIButton(gui, "S").setAutoSize(false)
+            .setSize(s, s)
+            .setTooltip("Strikethrough")
+            .register(this);
 
-        btnColor = new UIButton(gui, "C").setAutoSize(false).setSize(s, s).setTooltip("Color").register(this);
-        btnBgColor = new UIButton(gui, "BC").setAutoSize(false).setSize(16, s).setTooltip("Background Color")
-                .register(this);
-        btnItem = new UIButton(gui, "Item").setAutoSize(false).setSize(22, s).setTooltip("Item").register(this);
+        btnColor = new UIButton(gui, "C").setAutoSize(false)
+            .setSize(s, s)
+            .setTooltip("Color")
+            .register(this);
+        btnBgColor = new UIButton(gui, "BC").setAutoSize(false)
+            .setSize(16, s)
+            .setTooltip("Background Color")
+            .register(this);
+        btnItem = new UIButton(gui, "Item").setAutoSize(false)
+            .setSize(22, s)
+            .setTooltip("Item")
+            .register(this);
 
-        btnWysiwyg = new UIButton(gui, "WYSIWYG").setAutoSize(false).setSize(45, s).register(this);
+        btnWysiwyg = new UIButton(gui, "WYSIWYG").setAutoSize(false)
+            .setSize(45, s)
+            .register(this);
 
         menu.add(btnBold);
         menu.add(btnItalic);
@@ -205,7 +228,8 @@ public class BBCodeEditor extends UIContainer<BBCodeEditor> {
                 break;
         }
 
-        bbTexfield.setPosition(x, y).setSize(w, h);
+        bbTexfield.setPosition(x, y)
+            .setSize(w, h);
     }
 
     protected void calculateMenuPosition() {
@@ -228,7 +252,8 @@ public class BBCodeEditor extends UIContainer<BBCodeEditor> {
                 break;
         }
 
-        menu.setPosition(x, y, a).setSize(w, h);
+        menu.setPosition(x, y, a)
+            .setSize(w, h);
 
         calculateButtonPositions();
     }

--- a/src/main/java/net/malisis/core/util/bbcode/gui/BBTextField.java
+++ b/src/main/java/net/malisis/core/util/bbcode/gui/BBTextField.java
@@ -155,7 +155,9 @@ public class BBTextField extends UITextField implements IBBCodeRenderer<BBTextFi
                 str = getSelectedText();
             }
             addText(tag.node.toBBString());
-            getCursorPosition().jumpTo(p + tag.node.getTag().length() + 2);
+            getCursorPosition().jumpTo(
+                p + tag.node.getTag()
+                    .length() + 2);
             addText(str);
             return;
         }

--- a/src/main/java/net/malisis/core/util/bbcode/node/BBStyleNode.java
+++ b/src/main/java/net/malisis/core/util/bbcode/node/BBStyleNode.java
@@ -61,8 +61,10 @@ public class BBStyleNode extends BBNode {
     public void clean() {
         BBStyleNode node = getChildStyleNode(tag);
         if (node != null && node.getParent() != null) {
-            for (BBNode n : node) node.getParent().insertBefore(n, node);
-            node.getParent().remove(node);
+            for (BBNode n : node) node.getParent()
+                .insertBefore(n, node);
+            node.getParent()
+                .remove(node);
         }
 
         super.clean();

--- a/src/main/java/net/malisis/core/util/bbcode/render/BBRenderElement.java
+++ b/src/main/java/net/malisis/core/util/bbcode/render/BBRenderElement.java
@@ -82,6 +82,6 @@ public class BBRenderElement {
     @Override
     public String toString() {
         return styles.toString() + Integer
-                .toHexString(color) + "/" + Integer.toHexString(bgColor) + " : " + text + (newLine ? "~" : "");
+            .toHexString(color) + "/" + Integer.toHexString(bgColor) + " : " + text + (newLine ? "~" : "");
     }
 }

--- a/src/main/java/net/malisis/core/util/finiteliquid/FiniteLiquid.java
+++ b/src/main/java/net/malisis/core/util/finiteliquid/FiniteLiquid.java
@@ -142,7 +142,7 @@ public abstract class FiniteLiquid extends BlockDynamicLiquid {
 
     @Override
     public void addCollisionBoxesToList(World world, int x, int y, int z, AxisAlignedBB mask, List list,
-            Entity entity) {
+        Entity entity) {
         for (AxisAlignedBB aabb : getBoundingBox(world, x, y, z, BoundingBoxType.COLLISION)) {
             if (aabb != null && mask.intersectsWith(aabb.offset(x, y, z))) list.add(aabb);
         }
@@ -163,9 +163,10 @@ public abstract class FiniteLiquid extends BlockDynamicLiquid {
     @Override
     @SideOnly(Side.CLIENT)
     public boolean shouldSideBeRendered(IBlockAccess worldIn, int x, int y, int z, int side) {
-        Material material = worldIn.getBlock(x, y, z).getMaterial();
+        Material material = worldIn.getBlock(x, y, z)
+            .getMaterial();
         return material == this.blockMaterial ? false
-                : (side == 1 ? true : super.shouldSideBeRendered(worldIn, x, y, z, side));
+            : (side == 1 ? true : super.shouldSideBeRendered(worldIn, x, y, z, side));
     }
 
     @Override
@@ -225,7 +226,10 @@ public abstract class FiniteLiquid extends BlockDynamicLiquid {
         }
 
         public boolean process(BlockState state) {
-            BlockState down = new BlockState(world, state.getPos().down());
+            BlockState down = new BlockState(
+                world,
+                state.getPos()
+                    .down());
             int da = fl.getAmount(down);
             if (da != -1 && da != 16) {
                 int transfered = Math.min(amount, 4);
@@ -235,7 +239,8 @@ public abstract class FiniteLiquid extends BlockDynamicLiquid {
                 return amount > 0;
             }
 
-            if (state.getPos().equals(origin)) return true;
+            if (state.getPos()
+                .equals(origin)) return true;
 
             int a = fl.getAmount(state);
             if (a < amount - 1) {

--- a/src/main/java/net/malisis/core/util/finiteliquid/FiniteLiquidRenderer.java
+++ b/src/main/java/net/malisis/core/util/finiteliquid/FiniteLiquidRenderer.java
@@ -32,7 +32,8 @@ public class FiniteLiquidRenderer extends MalisisRenderer {
         }
 
         for (MergedVertex v : shape.getMergedVertexes(shape.getFace("top"))) {
-            int[][] aom = v.getBase().getAoMatrix(ForgeDirection.UP);
+            int[][] aom = v.getBase()
+                .getAoMatrix(ForgeDirection.UP);
             boolean air = false;
             float height = (float) blockMetadata / 16;
             int count = 1;

--- a/src/main/java/net/malisis/core/util/multiblock/MultiBlock.java
+++ b/src/main/java/net/malisis/core/util/multiblock/MultiBlock.java
@@ -59,16 +59,20 @@ public abstract class MultiBlock implements Iterable<BlockState>, IBlockAccess {
 
     public boolean canPlaceBlockAt(World world, BlockPos pos) {
         for (BlockState state : this) {
-            BlockPos p = state.getPos().add(pos);
-            if (!state.getBlock().canPlaceBlockAt(world, p.getX(), p.getY(), p.getZ())) return false;
+            BlockPos p = state.getPos()
+                .add(pos);
+            if (!state.getBlock()
+                .canPlaceBlockAt(world, p.getX(), p.getY(), p.getZ())) return false;
         }
         return true;
     }
 
     public void placeBlocks(World world, BlockPos pos) {
         for (BlockState state : this) {
-            state = state.rotate(rotation).offset(pos);
-            if (!state.getPos().equals(pos)) {
+            state = state.rotate(rotation)
+                .offset(pos);
+            if (!state.getPos()
+                .equals(pos)) {
                 state.placeBlock(world, 2);
                 state.rotateInWorld(world, rotation);
             }
@@ -77,8 +81,10 @@ public abstract class MultiBlock implements Iterable<BlockState>, IBlockAccess {
 
     public void breakBlocks(World world, BlockPos pos) {
         for (BlockState state : this) {
-            state = state.rotate(rotation).offset(pos);
-            if (!state.getPos().equals(pos)) state.breakBlock(world, 2);
+            state = state.rotate(rotation)
+                .offset(pos);
+            if (!state.getPos()
+                .equals(pos)) state.breakBlock(world, 2);
         }
     }
 
@@ -97,7 +103,8 @@ public abstract class MultiBlock implements Iterable<BlockState>, IBlockAccess {
 
     @Override
     public Iterator<BlockState> iterator() {
-        return states.values().iterator();
+        return states.values()
+            .iterator();
     }
 
     protected abstract void buildStates();

--- a/src/main/java/net/malisis/core/util/parser/HTMLParser.java
+++ b/src/main/java/net/malisis/core/util/parser/HTMLParser.java
@@ -162,9 +162,9 @@ public class HTMLParser extends Parser<HTMLNode> {
             int n = 4;
             if (text != null) return StringUtils.repeat(' ', level * n) + text + "\n";
             String s = StringUtils.repeat(' ', level * n) + "<"
-                    + name
-                    + (attributes.size() != 0 ? " " + attributes.toString() : "")
-                    + ">\n";
+                + name
+                + (attributes.size() != 0 ? " " + attributes.toString() : "")
+                + ">\n";
             for (HTMLNode node : nodes) s += node.prettyPrint();
             if (nodes.size() != 0) s += StringUtils.repeat(' ', level * n) + "</" + name + ">\n";
 

--- a/src/main/java/net/malisis/core/util/parser/token/KeywordToken.java
+++ b/src/main/java/net/malisis/core/util/parser/token/KeywordToken.java
@@ -28,7 +28,9 @@ public class KeywordToken extends Token<String> {
         if (value == null) return false;
         int e = index + value.length();
         if (e > s.length()) return false;
-        if (s.substring(index, index + value.length()).toLowerCase().equals(value.toLowerCase())) return true;
+        if (s.substring(index, index + value.length())
+            .toLowerCase()
+            .equals(value.toLowerCase())) return true;
         return false;
     }
 

--- a/src/main/java/net/malisis/core/util/parser/token/Token.java
+++ b/src/main/java/net/malisis/core/util/parser/token/Token.java
@@ -61,7 +61,7 @@ public abstract class Token<T> {
 
     // SPECIAL TOKENS
     public static ExpressionToken Identifier = (ExpressionToken) new ExpressionToken("^[^\\d\\W]\\w*")
-            .name("Identifier");
+        .name("Identifier");
     public static ExpressionToken Number = (ExpressionToken) new ExpressionToken("^\\d+").name("Number");
     public static ExpressionToken HexNumber = (ExpressionToken) new ExpressionToken("^#[0-9a-fA-F]+").name("HexNumber");
     public static StringToken StringToken = (StringToken) new StringToken().name("StringToken");

--- a/src/main/java/net/malisis/core/util/replacement/ReplacementHandler.java
+++ b/src/main/java/net/malisis/core/util/replacement/ReplacementHandler.java
@@ -61,7 +61,7 @@ public abstract class ReplacementHandler<T> {
         if (replaced instanceof Item) return itemStack.getItem() == replaced;
 
         return replaced instanceof Block && itemStack.getItem() instanceof ItemBlock
-                && ((ItemBlock) itemStack.getItem()).field_150939_a == replaced;
+            && ((ItemBlock) itemStack.getItem()).field_150939_a == replaced;
     }
 
     public abstract boolean replace(T object, Object vanilla, Object replacement);

--- a/src/main/java/net/malisis/core/util/replacement/ReplacementTool.java
+++ b/src/main/java/net/malisis/core/util/replacement/ReplacementTool.java
@@ -57,10 +57,10 @@ public class ReplacementTool {
 
     private Class[] types = { Integer.TYPE, String.class, Object.class };
     private Method method = ReflectionHelper.findMethod(
-            FMLControlledNamespacedRegistry.class,
-            (FMLControlledNamespacedRegistry) null,
-            new String[] { "addObjectRaw" },
-            types);
+        FMLControlledNamespacedRegistry.class,
+        (FMLControlledNamespacedRegistry) null,
+        new String[] { "addObjectRaw" },
+        types);
 
     private ReplacementTool() {
         new ShapedOreRecipeHandler();
@@ -121,7 +121,7 @@ public class ReplacementTool {
         try {
             method.invoke(registry, id, "minecraft:" + name, replacement);
             final Fields.ClassFields.Field field = Fields.ofClass(clazz)
-                    .getUntypedField(Fields.LookupType.DECLARED, MalisisCore.isObfEnv ? srgFieldName : name);
+                .getUntypedField(Fields.LookupType.DECLARED, MalisisCore.isObfEnv ? srgFieldName : name);
             field.setValue(null, replacement);
 
             if (ib != null) {
@@ -129,7 +129,11 @@ public class ReplacementTool {
             }
 
             map.put(replacement, vanilla);
-            replaceIn(CraftingManager.getInstance().getRecipeList(), vanilla, replacement);
+            replaceIn(
+                CraftingManager.getInstance()
+                    .getRecipeList(),
+                vanilla,
+                replacement);
             replaceIn(StatList.allStats, vanilla, replacement);
         } catch (ReflectiveOperationException e) {
             e.printStackTrace();
@@ -141,10 +145,13 @@ public class ReplacementTool {
             ReplacementHandler rh = ReplacementHandler.getHandler(object);
             if (rh != null) {
                 if (rh.replace(object, vanilla, replacement)) MalisisCore.log.info(
-                        "Replaced {} by {} in {}",
-                        vanilla.getClass().getSimpleName(),
-                        replacement.getClass().getSimpleName(),
-                        object.getClass().getSimpleName());
+                    "Replaced {} by {} in {}",
+                    vanilla.getClass()
+                        .getSimpleName(),
+                    replacement.getClass()
+                        .getSimpleName(),
+                    object.getClass()
+                        .getSimpleName());
             }
         }
     }

--- a/src/main/java/net/malisis/core/util/replacement/ShapedOreRecipeHandler.java
+++ b/src/main/java/net/malisis/core/util/replacement/ShapedOreRecipeHandler.java
@@ -34,7 +34,8 @@ public class ShapedOreRecipeHandler extends ReplacementHandler<ShapedOreRecipe> 
         try {
             Field field = ShapedOreRecipe.class.getDeclaredField("output");
             field.setAccessible(true);
-            outputField = MethodHandles.lookup().unreflectSetter(field);
+            outputField = MethodHandles.lookup()
+                .unreflectSetter(field);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException("Failed to access ShapedOreRecipe.output", e);
         }

--- a/src/main/java/net/malisis/core/util/replacement/ShapelessOreRecipeHandler.java
+++ b/src/main/java/net/malisis/core/util/replacement/ShapelessOreRecipeHandler.java
@@ -35,7 +35,8 @@ public class ShapelessOreRecipeHandler extends ReplacementHandler<ShapelessOreRe
         try {
             Field field = ShapelessOreRecipe.class.getDeclaredField("output");
             field.setAccessible(true);
-            outputField = MethodHandles.lookup().unreflectSetter(field);
+            outputField = MethodHandles.lookup()
+                .unreflectSetter(field);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException("Failed to access ShapelessOreRecipe.output", e);
         }

--- a/src/main/java/net/malisis/core/util/syncer/Syncer.java
+++ b/src/main/java/net/malisis/core/util/syncer/Syncer.java
@@ -148,12 +148,15 @@ public class Syncer {
      * @return the field values
      */
     private Map<String, Object> getFieldValues(Object caller, ISyncHandler<?, ? extends ISyncableData> handler,
-            String... syncNames) {
+        String... syncNames) {
         Map<String, Object> values = new LinkedHashMap<>();
         try {
             for (String str : syncNames) {
                 FieldData fd = handler.getFieldData(str);
-                if (fd != null) values.put(str, fd.getField().get(caller));
+                if (fd != null) values.put(
+                    str,
+                    fd.getField()
+                        .get(caller));
             }
         } catch (IllegalArgumentException | IllegalAccessException e) {
             e.printStackTrace();
@@ -196,19 +199,21 @@ public class Syncer {
      * @param values   the values
      */
     public void updateValues(Object receiver, ISyncHandler<?, ? extends ISyncableData> handler,
-            Map<String, Object> values) {
+        Map<String, Object> values) {
         if (receiver == null || handler == null) return;
 
         for (Entry<String, Object> entry : values.entrySet()) {
             try {
                 FieldData fd = handler.getFieldData(entry.getKey());
-                if (fd != null) fd.getField().set(receiver, entry.getValue());
+                if (fd != null) fd.getField()
+                    .set(receiver, entry.getValue());
             } catch (IllegalArgumentException | IllegalAccessException e) {
                 MalisisCore.log.error(
-                        "Failed to update {} field for {}.",
-                        entry.getKey(),
-                        receiver.getClass().getSimpleName(),
-                        e);
+                    "Failed to update {} field for {}.",
+                    entry.getKey(),
+                    receiver.getClass()
+                        .getSimpleName(),
+                    e);
             }
         }
     }

--- a/src/main/java/net/malisis/core/util/syncer/handlers/TileEntitySyncHandler.java
+++ b/src/main/java/net/malisis/core/util/syncer/handlers/TileEntitySyncHandler.java
@@ -47,8 +47,9 @@ public class TileEntitySyncHandler extends DefaultSyncHandler<TileEntity, TESync
     @Override
     public void send(TileEntity caller, Packet packet) {
         MalisisCore.network.sendToPlayersWatchingChunk(
-                packet,
-                caller.getWorldObj().getChunkFromChunkCoords(caller.xCoord >> 4, caller.zCoord >> 4));
+            packet,
+            caller.getWorldObj()
+                .getChunkFromChunkCoords(caller.xCoord >> 4, caller.zCoord >> 4));
     }
 
     public static class TESyncData implements ISyncableData {

--- a/src/main/java/net/malisis/core/util/syncer/message/SyncerMessage.java
+++ b/src/main/java/net/malisis/core/util/syncer/message/SyncerMessage.java
@@ -57,7 +57,8 @@ public class SyncerMessage implements IMessageHandler<SyncerMessage.Packet, IMes
     public IMessage onMessage(Packet message, MessageContext ctx) {
         if (ctx.side == Side.CLIENT) {
             Object caller = message.handler.getReceiver(ctx, message.data);
-            Syncer.get().updateValues(caller, message.handler, message.values);
+            Syncer.get()
+                .updateValues(caller, message.handler, message.values);
         }
 
         return null;
@@ -73,7 +74,7 @@ public class SyncerMessage implements IMessageHandler<SyncerMessage.Packet, IMes
         public Packet() {}
 
         public Packet(ISyncHandler<? super T, ? extends ISyncableData> handler, ISyncableData data, int fieldIndexes,
-                Map<String, Object> fieldValues) {
+            Map<String, Object> fieldValues) {
             this.handler = handler;
             this.data = data;
             this.indexes = fieldIndexes;
@@ -83,7 +84,8 @@ public class SyncerMessage implements IMessageHandler<SyncerMessage.Packet, IMes
         @Override
         public void fromBytes(ByteBuf buf) {
             // handler
-            handler = (ISyncHandler<? super T, ? extends ISyncableData>) Syncer.get().getHandlerFromId(buf.readInt());
+            handler = (ISyncHandler<? super T, ? extends ISyncableData>) Syncer.get()
+                .getHandlerFromId(buf.readInt());
             if (handler == null) return;
 
             // data
@@ -103,7 +105,8 @@ public class SyncerMessage implements IMessageHandler<SyncerMessage.Packet, IMes
                 if ((indexes & 1) != 0) {
                     data = null;
                     FieldData fd = handler.getFieldData(index);
-                    clazz = fd.getField().getType();
+                    clazz = fd.getField()
+                        .getType();
 
                     if (ISyncableData.class.isAssignableFrom(clazz)) {
                         if (buf.readBoolean()) {
@@ -136,7 +139,9 @@ public class SyncerMessage implements IMessageHandler<SyncerMessage.Packet, IMes
         @Override
         public void toBytes(ByteBuf buf) {
             // handler
-            buf.writeInt(Syncer.get().getHandlerId(handler));
+            buf.writeInt(
+                Syncer.get()
+                    .getHandlerId(handler));
             // data
             data.toBytes(buf);
             // indexes

--- a/src/main/java/net/malisis/doors/MalisisDoors.java
+++ b/src/main/java/net/malisis/doors/MalisisDoors.java
@@ -1,5 +1,7 @@
 package net.malisis.doors;
 
+import static net.malisis.doors.Tags.VERSION;
+
 import net.malisis.core.IMalisisMod;
 import net.malisis.core.MalisisCore;
 import net.malisis.core.configuration.Settings;
@@ -30,10 +32,10 @@ import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 
 @Mod(
-        modid = MalisisDoors.modid,
-        name = MalisisDoors.modname,
-        version = MalisisDoors.version,
-        dependencies = "required-after:malisiscore")
+    modid = MalisisDoors.modid,
+    name = MalisisDoors.modname,
+    version = VERSION,
+    dependencies = "required-after:malisiscore")
 public class MalisisDoors implements IMalisisMod {
 
     @SidedProxy(clientSide = "net.malisis.doors.proxy.ClientProxy", serverSide = "net.malisis.doors.proxy.ServerProxy")
@@ -41,7 +43,6 @@ public class MalisisDoors implements IMalisisMod {
 
     public static final String modid = "malisisdoors";
     public static final String modname = "Malisis' Doors";
-    public static final String version = "GRADLETOKEN_VERSION";
 
     public static MalisisDoors instance;
     public static MalisisNetwork network;
@@ -68,7 +69,7 @@ public class MalisisDoors implements IMalisisMod {
 
     @Override
     public String getVersion() {
-        return version;
+        return VERSION;
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/MalisisDoorsSettings.java
+++ b/src/main/java/net/malisis/doors/MalisisDoorsSettings.java
@@ -31,13 +31,13 @@ public class MalisisDoorsSettings extends Settings {
 
     @ConfigurationSetting
     public static Setting<Boolean> enhancedMixedBlockPlacement = new BooleanSetting(
-            "config.enhancedMixedBlockPlacement",
-            true);
+        "config.enhancedMixedBlockPlacement",
+        true);
 
     @ConfigurationSetting
     public static Setting<Boolean> simpleMixedBlockRendering = new BooleanSetting(
-            "config.simpleMixedBlockRendering",
-            false);
+        "config.simpleMixedBlockRendering",
+        false);
 
     @ConfigurationSetting
     public static Setting<Boolean> enableVanishingBlocks = new BooleanSetting("config.enableVanishingBlocks", true);
@@ -59,12 +59,11 @@ public class MalisisDoorsSettings extends Settings {
     protected void initSettings() {
         modifyVanillaDoors.setComment("config.modifyVanillaDoors.comment1", "config.modifyVanillaDoors.comment2");
         simpleMixedBlockRendering
-                .setComment("config.simpleMixedBlockRendering.comment1", "config.simpleMixedBlockRendering.comment2");
+            .setComment("config.simpleMixedBlockRendering.comment1", "config.simpleMixedBlockRendering.comment2");
         enableVanishingGlitch.setComment("config.enableVanishingGlitch.comment");
         vanishingGlitchChance.setComment("config.vanishingGlitchChance.comment");
-        enhancedMixedBlockPlacement.setComment(
-                "config.enhancedMixedBlockPlacement.comment1",
-                "config.enhancedMixedBlockPlacement.comment2");
+        enhancedMixedBlockPlacement
+            .setComment("config.enhancedMixedBlockPlacement.comment1", "config.enhancedMixedBlockPlacement.comment2");
         enableCamoFenceGate.setComment("config.enableCamoFenceGate.comment");
     }
 }

--- a/src/main/java/net/malisis/doors/ProxyAccess.java
+++ b/src/main/java/net/malisis/doors/ProxyAccess.java
@@ -140,11 +140,11 @@ public class ProxyAccess {
 
         public ProxyWorld(World world) {
             super(
-                    world.getSaveHandler(),
-                    "ProxyWorld",
-                    new WorldSettings(world.getWorldInfo()),
-                    world.provider,
-                    (Profiler) null);
+                world.getSaveHandler(),
+                "ProxyWorld",
+                new WorldSettings(world.getWorldInfo()),
+                world.provider,
+                (Profiler) null);
             original = world;
             // reset back the world for the provider
             provider.worldObj = world;

--- a/src/main/java/net/malisis/doors/Registers.java
+++ b/src/main/java/net/malisis/doors/Registers.java
@@ -123,9 +123,9 @@ public class Registers {
         VanillaDoor woodDoor = new VanillaDoor(Material.wood);
         woodDoor.create();
         ReplacementTool
-                .replaceVanillaItem(324, "wooden_door", "field_151135_aq", woodDoor.getItem(), Items.wooden_door);
+            .replaceVanillaItem(324, "wooden_door", "field_151135_aq", woodDoor.getItem(), Items.wooden_door);
         ReplacementTool
-                .replaceVanillaBlock(64, "wooden_door", "field_150466_ao", woodDoor.getBlock(), Blocks.wooden_door);
+            .replaceVanillaBlock(64, "wooden_door", "field_150466_ao", woodDoor.getBlock(), Blocks.wooden_door);
 
         VanillaDoor ironDoor = new VanillaDoor(Material.iron);
         ironDoor.create();
@@ -137,7 +137,7 @@ public class Registers {
         VanillaTrapDoor vanillaTrapDoor = new VanillaTrapDoor();
         vanillaTrapDoor.create();
         ReplacementTool
-                .replaceVanillaBlock(96, "trapdoor", "field_150415_aT", vanillaTrapDoor.getBlock(), Blocks.trapdoor);
+            .replaceVanillaBlock(96, "trapdoor", "field_150415_aT", vanillaTrapDoor.getBlock(), Blocks.trapdoor);
     }
 
     private static void registerVanillaFenceGate() {
@@ -245,20 +245,23 @@ public class Registers {
     private static void registerPlayerSensor() {
         playerSensor = new PlayerSensor();
 
-        GameRegistry.registerBlock(playerSensor, playerSensor.getUnlocalizedName().substring(5));
+        GameRegistry.registerBlock(
+            playerSensor,
+            playerSensor.getUnlocalizedName()
+                .substring(5));
 
         // Sensor recipe
         GameRegistry.addRecipe(
-                new ShapedOreRecipe(
-                        new ItemStack(playerSensor),
-                        "ABA",
-                        "CCC",
-                        'A',
-                        Items.iron_ingot,
-                        'B',
-                        Items.redstone,
-                        'C',
-                        "blockGlassColorless"));
+            new ShapedOreRecipe(
+                new ItemStack(playerSensor),
+                "ABA",
+                "CCC",
+                'A',
+                Items.iron_ingot,
+                'B',
+                Items.redstone,
+                'C',
+                "blockGlassColorless"));
     }
 
     private static void registerVanishingBlock() {
@@ -266,56 +269,60 @@ public class Registers {
         vanishingDiamondBlock = new VanishingDiamondBlock();
 
         GameRegistry.registerBlock(
-                vanishingBlock,
-                VanishingBlockItem.class,
-                vanishingBlock.getUnlocalizedName().substring(5));
-        GameRegistry.registerBlock(vanishingDiamondBlock, vanishingDiamondBlock.getUnlocalizedName().substring(5));
+            vanishingBlock,
+            VanishingBlockItem.class,
+            vanishingBlock.getUnlocalizedName()
+                .substring(5));
+        GameRegistry.registerBlock(
+            vanishingDiamondBlock,
+            vanishingDiamondBlock.getUnlocalizedName()
+                .substring(5));
 
         // Vanishing Block Recipes
         GameRegistry.addRecipe(
-                new ItemStack(vanishingBlock, 4, 0),
-                "ABA",
-                "BCB",
-                "ABA",
-                'A',
-                Items.redstone,
-                'B',
-                Items.stick,
-                'C',
-                Items.ender_pearl);
+            new ItemStack(vanishingBlock, 4, 0),
+            "ABA",
+            "BCB",
+            "ABA",
+            'A',
+            Items.redstone,
+            'B',
+            Items.stick,
+            'C',
+            Items.ender_pearl);
         GameRegistry.addRecipe(
-                new ItemStack(vanishingBlock, 4, 1),
-                "ABA",
-                "BCB",
-                "ABA",
-                'A',
-                Items.redstone,
-                'B',
-                Items.iron_ingot,
-                'C',
-                Items.ender_pearl);
+            new ItemStack(vanishingBlock, 4, 1),
+            "ABA",
+            "BCB",
+            "ABA",
+            'A',
+            Items.redstone,
+            'B',
+            Items.iron_ingot,
+            'C',
+            Items.ender_pearl);
         GameRegistry.addRecipe(
-                new ItemStack(vanishingBlock, 4, 2),
-                "ABA",
-                "BCB",
-                "ABA",
-                'A',
-                Items.redstone,
-                'B',
-                Items.gold_ingot,
-                'C',
-                Items.ender_pearl);
+            new ItemStack(vanishingBlock, 4, 2),
+            "ABA",
+            "BCB",
+            "ABA",
+            'A',
+            Items.redstone,
+            'B',
+            Items.gold_ingot,
+            'C',
+            Items.ender_pearl);
         GameRegistry.addRecipe(
-                new ItemStack(vanishingBlock, 4, 3),
-                "ABA",
-                "BCB",
-                "ABA",
-                'A',
-                Items.redstone,
-                'B',
-                Items.diamond,
-                'C',
-                Items.ender_pearl);
+            new ItemStack(vanishingBlock, 4, 3),
+            "ABA",
+            "BCB",
+            "ABA",
+            'A',
+            Items.redstone,
+            'B',
+            Items.diamond,
+            'C',
+            Items.ender_pearl);
 
         GameRegistry.registerTileEntity(VanishingTileEntity.class, "vanishingTileEntity");
         GameRegistry.registerTileEntity(VanishingDiamondTileEntity.class, "vanishingDiamondTileEntity");
@@ -325,12 +332,19 @@ public class Registers {
         blockMixer = new BlockMixer();
         mixedBlock = new MixedBlock();
 
-        GameRegistry.registerBlock(blockMixer, blockMixer.getUnlocalizedName().substring(5));
-        GameRegistry.registerBlock(mixedBlock, MixedBlockBlockItem.class, mixedBlock.getUnlocalizedName().substring(5));
+        GameRegistry.registerBlock(
+            blockMixer,
+            blockMixer.getUnlocalizedName()
+                .substring(5));
+        GameRegistry.registerBlock(
+            mixedBlock,
+            MixedBlockBlockItem.class,
+            mixedBlock.getUnlocalizedName()
+                .substring(5));
 
         // Block Mixer recipe
         GameRegistry
-                .addRecipe(new ItemStack(blockMixer), "AAA", "B B", "AAA", 'A', Items.iron_ingot, 'B', Blocks.piston);
+            .addRecipe(new ItemStack(blockMixer), "AAA", "B B", "AAA", 'A', Items.iron_ingot, 'B', Blocks.piston);
 
         GameRegistry.registerTileEntity(BlockMixerTileEntity.class, "blockMixerTileEntity");
         GameRegistry.registerTileEntity(MixedBlockTileEntity.class, "mixedBlockTileEntity");
@@ -339,7 +353,10 @@ public class Registers {
     private static void registerGarageDoor() {
         garageDoor = new GarageDoor();
 
-        GameRegistry.registerBlock(garageDoor, garageDoor.getUnlocalizedName().substring(5));
+        GameRegistry.registerBlock(
+            garageDoor,
+            garageDoor.getUnlocalizedName()
+                .substring(5));
 
         GameRegistry.registerTileEntity(GarageDoorTileEntity.class, "garageDoorTileEntity");
 
@@ -353,23 +370,26 @@ public class Registers {
         GameRegistry.registerTileEntity(DoorFactoryTileEntity.class, "doorFactoryTileEntity");
 
         GameRegistry.addRecipe(
-                new ItemStack(doorFactory),
-                "ABA",
-                "C C",
-                "ADA",
-                'A',
-                Items.iron_ingot,
-                'B',
-                Items.iron_door,
-                'C',
-                Items.redstone,
-                'D',
-                Blocks.piston);
+            new ItemStack(doorFactory),
+            "ABA",
+            "C C",
+            "ADA",
+            'A',
+            Items.iron_ingot,
+            'B',
+            Items.iron_door,
+            'C',
+            Items.redstone,
+            'D',
+            Blocks.piston);
     }
 
     private static void registerCustomDoor() {
         customDoor = new CustomDoor();
-        GameRegistry.registerBlock(customDoor, customDoor.getUnlocalizedName().substring(5));
+        GameRegistry.registerBlock(
+            customDoor,
+            customDoor.getUnlocalizedName()
+                .substring(5));
 
         customDoorItem = new CustomDoorItem();
         GameRegistry.registerItem(customDoorItem, customDoorItem.getUnlocalizedName());
@@ -385,7 +405,8 @@ public class Registers {
 
             @Override
             public void registerIcons(IIconRegister register) {};
-        }.setUnlocalizedName("rustyHandle").setCreativeTab(MalisisDoors.tab);
+        }.setUnlocalizedName("rustyHandle")
+            .setCreativeTab(MalisisDoors.tab);
         GameRegistry.registerItem(rustyHandle, rustyHandle.getUnlocalizedName());
 
         GameRegistry.registerTileEntity(RustyHatchTileEntity.class, "rustyHatchTileEntity");
@@ -394,7 +415,10 @@ public class Registers {
         GameRegistry.addRecipe(new ItemStack(rustyHatch), "A ", "AB", "A ", 'A', Items.iron_ingot, 'B', rustyHandle);
 
         rustyLadder = new RustyLadder();
-        GameRegistry.registerBlock(rustyLadder, rustyLadder.getUnlocalizedName().substring(5));
+        GameRegistry.registerBlock(
+            rustyLadder,
+            rustyLadder.getUnlocalizedName()
+                .substring(5));
         GameRegistry.addRecipe(new ItemStack(rustyLadder), "AAA", 'A', Items.iron_ingot);
     }
 
@@ -405,10 +429,8 @@ public class Registers {
         medievalDoor = new BigDoor(BigDoor.Type.MEDIEVAL);
         medievalDoor.register();
 
-        GameRegistry.registerTileEntityWithAlternatives(
-                BigDoorTileEntity.class,
-                "bigDoorTileEntity",
-                "carriageDoorTileEntity");
+        GameRegistry
+            .registerTileEntityWithAlternatives(BigDoorTileEntity.class, "bigDoorTileEntity", "carriageDoorTileEntity");
 
         GameRegistry.addRecipe(new BigDoorRecipe(BigDoor.Type.CARRIAGE));
         GameRegistry.addRecipe(new BigDoorRecipe(BigDoor.Type.MEDIEVAL));
@@ -416,26 +438,29 @@ public class Registers {
 
     private static void registerForcefieldDoor() {
         forcefieldDoor = new ForcefieldDoor();
-        GameRegistry.registerBlock(forcefieldDoor, forcefieldDoor.getUnlocalizedName().substring(5));
+        GameRegistry.registerBlock(
+            forcefieldDoor,
+            forcefieldDoor.getUnlocalizedName()
+                .substring(5));
 
         forcefieldItem = new ForcefieldItem();
         GameRegistry.registerItem(forcefieldItem, forcefieldItem.getUnlocalizedName());
 
         GameRegistry.registerTileEntity(ForcefieldTileEntity.class, "forcefieldTileEntity");
         GameRegistry.addRecipe(
-                new ItemStack(forcefieldItem),
-                "ABA",
-                "CDC",
-                "AEA",
-                'A',
-                Items.diamond,
-                'B',
-                Blocks.obsidian,
-                'C',
-                Items.repeater,
-                'D',
-                Items.ender_eye,
-                'E',
-                Items.comparator);
+            new ItemStack(forcefieldItem),
+            "ABA",
+            "CDC",
+            "AEA",
+            'A',
+            Items.diamond,
+            'B',
+            Blocks.obsidian,
+            'C',
+            Items.repeater,
+            'D',
+            Items.ender_eye,
+            'E',
+            Items.comparator);
     }
 }

--- a/src/main/java/net/malisis/doors/block/BlockMixer.java
+++ b/src/main/java/net/malisis/doors/block/BlockMixer.java
@@ -48,9 +48,15 @@ public class BlockMixer extends Block implements ITileEntityProvider {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerBlockIcons(IIconRegister iconRegister) {
-        this.blockIcon = iconRegister
-                .registerIcon(MalisisDoors.modid + ":" + (this.getUnlocalizedName().substring(5)) + "_side");
-        this.frontIcon = iconRegister.registerIcon(MalisisDoors.modid + ":" + (this.getUnlocalizedName().substring(5)));
+        this.blockIcon = iconRegister.registerIcon(
+            MalisisDoors.modid + ":"
+                + (this.getUnlocalizedName()
+                    .substring(5))
+                + "_side");
+        this.frontIcon = iconRegister.registerIcon(
+            MalisisDoors.modid + ":"
+                + (this.getUnlocalizedName()
+                    .substring(5)));
     }
 
     @Override
@@ -72,7 +78,7 @@ public class BlockMixer extends Block implements ITileEntityProvider {
 
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int metadata, float hitX,
-            float hitY, float hitZ) {
+        float hitY, float hitZ) {
         if (world.isRemote) return true;
 
         if (player.isSneaking()) return false;

--- a/src/main/java/net/malisis/doors/block/DoorFactory.java
+++ b/src/main/java/net/malisis/doors/block/DoorFactory.java
@@ -76,7 +76,7 @@ public class DoorFactory extends MalisisBlock implements ITileEntityProvider {
 
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int metadata, float hitX,
-            float hitY, float hitZ) {
+        float hitY, float hitZ) {
         if (world.isRemote) return true;
 
         if (player.isSneaking()) return false;

--- a/src/main/java/net/malisis/doors/block/GarageDoor.java
+++ b/src/main/java/net/malisis/doors/block/GarageDoor.java
@@ -54,9 +54,15 @@ public class GarageDoor extends Block implements ITileEntityProvider {
 
     @Override
     public void registerBlockIcons(IIconRegister iconRegister) {
-        this.blockIcon = iconRegister.registerIcon(MalisisDoors.modid + ":" + (this.getUnlocalizedName().substring(5)));
-        this.topBlockIcon = iconRegister
-                .registerIcon(MalisisDoors.modid + ":" + (this.getUnlocalizedName().substring(5)) + "_top");
+        this.blockIcon = iconRegister.registerIcon(
+            MalisisDoors.modid + ":"
+                + (this.getUnlocalizedName()
+                    .substring(5)));
+        this.topBlockIcon = iconRegister.registerIcon(
+            MalisisDoors.modid + ":"
+                + (this.getUnlocalizedName()
+                    .substring(5))
+                + "_top");
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/block/MixedBlock.java
+++ b/src/main/java/net/malisis/doors/block/MixedBlock.java
@@ -55,7 +55,7 @@ public class MixedBlock extends Block implements ITileEntityProvider {
 
     @Override
     public int onBlockPlaced(World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ,
-            int metadata) {
+        int metadata) {
         return side;
     }
 
@@ -147,7 +147,8 @@ public class MixedBlock extends Block implements ITileEntityProvider {
         int i = world.rand.nextBoolean() ? 0 : 1;
 
         EntityDiggingFX fx = new EntityDiggingFX(world, fxX, fxY, fxZ, 0.0D, 0.0D, 0.0D, blocks[i], metadata[i]);
-        fx.multiplyVelocity(0.2F).multipleParticleScaleBy(0.6F);
+        fx.multiplyVelocity(0.2F)
+            .multipleParticleScaleBy(0.6F);
         effectRenderer.addEffect(fx);
 
         return true;
@@ -173,15 +174,15 @@ public class MixedBlock extends Block implements ITileEntityProvider {
                     double fxZ = z + (k + 0.5D) / nb;
                     int l = (i + j + k) % 2;
                     fx = new EntityDiggingFX(
-                            world,
-                            fxX,
-                            fxY,
-                            fxZ,
-                            fxX - x - 0.5D,
-                            fxY - y - 0.5D,
-                            fxZ - z - 0.5D,
-                            blocks[l],
-                            metadata[l]);
+                        world,
+                        fxX,
+                        fxY,
+                        fxZ,
+                        fxX - x - 0.5D,
+                        fxY - y - 0.5D,
+                        fxZ - z - 0.5D,
+                        blocks[l],
+                        metadata[l]);
                     effectRenderer.addEffect(fx);
                 }
             }
@@ -233,9 +234,10 @@ public class MixedBlock extends Block implements ITileEntityProvider {
         Block block = world.getBlock(x, y, z);
         if (block != this && !(block instanceof BlockBreakable)) return !block.isOpaqueCube();
 
-        ForgeDirection op = ForgeDirection.getOrientation(side).getOpposite();
+        ForgeDirection op = ForgeDirection.getOrientation(side)
+            .getOpposite();
         MixedBlockTileEntity current = TileEntityUtils
-                .getTileEntity(MixedBlockTileEntity.class, world, x + op.offsetX, y + op.offsetY, z + op.offsetZ);
+            .getTileEntity(MixedBlockTileEntity.class, world, x + op.offsetX, y + op.offsetY, z + op.offsetZ);
 
         return !isOpaque(world, x, y, z) && current.isOpaque();
     }

--- a/src/main/java/net/malisis/doors/block/PlayerSensor.java
+++ b/src/main/java/net/malisis/doors/block/PlayerSensor.java
@@ -31,7 +31,10 @@ public class PlayerSensor extends Block {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerBlockIcons(IIconRegister iconRegister) {
-        this.blockIcon = iconRegister.registerIcon(MalisisDoors.modid + ":" + (this.getUnlocalizedName().substring(5)));
+        this.blockIcon = iconRegister.registerIcon(
+            MalisisDoors.modid + ":"
+                + (this.getUnlocalizedName()
+                    .substring(5)));
     }
 
     @Override
@@ -65,7 +68,7 @@ public class PlayerSensor extends Block {
 
     @Override
     public int onBlockPlaced(World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ,
-            int metadata) {
+        int metadata) {
         return side + (world.getBlockMetadata(x, y, z) & FLAG_POWERED);
     }
 

--- a/src/main/java/net/malisis/doors/block/VanishingBlock.java
+++ b/src/main/java/net/malisis/doors/block/VanishingBlock.java
@@ -128,8 +128,7 @@ public class VanishingBlock extends BlockContainer {
         if ((source.getBlockMetadata() & 3) == typeIronFrame && source.copiedBlock == dest.copiedBlock) return true;
 
         if ((source.getBlockMetadata() & 3) == typeGoldFrame && source.copiedBlock == dest.copiedBlock
-                && source.copiedMetadata == dest.copiedMetadata)
-            return true;
+            && source.copiedMetadata == dest.copiedMetadata) return true;
 
         return false;
     }
@@ -148,7 +147,7 @@ public class VanishingBlock extends BlockContainer {
     // #region Events
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer p, int side, float hitX, float hitY,
-            float hitZ) {
+        float hitZ) {
         ItemStack is = p.getHeldItem();
         if (is == null) return false;
 
@@ -209,7 +208,7 @@ public class VanishingBlock extends BlockContainer {
     @SuppressWarnings("rawtypes")
     @Override
     public void addCollisionBoxesToList(World world, int x, int y, int z, AxisAlignedBB mask, List list,
-            Entity entity) {
+        Entity entity) {
         if ((world.getBlockMetadata(x, y, z) & (flagPowered | flagInTransition)) != 0) return;
 
         VanishingTileEntity te = TileEntityUtils.getTileEntity(VanishingTileEntity.class, world, x, y, z);

--- a/src/main/java/net/malisis/doors/block/VanishingDiamondBlock.java
+++ b/src/main/java/net/malisis/doors/block/VanishingDiamondBlock.java
@@ -64,7 +64,7 @@ public class VanishingDiamondBlock extends VanishingBlock {
 
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX,
-            float hitY, float hitZ) {
+        float hitY, float hitZ) {
         if (world.isRemote) return true;
 
         IInventoryProvider te = TileEntityUtils.getTileEntity(IInventoryProvider.class, world, x, y, z);

--- a/src/main/java/net/malisis/doors/door/DoorDescriptor.java
+++ b/src/main/java/net/malisis/doors/door/DoorDescriptor.java
@@ -280,7 +280,10 @@ public class DoorDescriptor {
     public DoorDescriptor register() {
         if (block == null || item == null) create();
 
-        GameRegistry.registerBlock(block, block.getUnlocalizedName().substring(5));
+        GameRegistry.registerBlock(
+            block,
+            block.getUnlocalizedName()
+                .substring(5));
         GameRegistry.registerItem(item, item.getUnlocalizedName());
         if (recipe != null) {
             if (oredict) GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(item, numCrafted), recipe));

--- a/src/main/java/net/malisis/doors/door/DoorRegistry.java
+++ b/src/main/java/net/malisis/doors/door/DoorRegistry.java
@@ -110,10 +110,11 @@ public class DoorRegistry {
      * @return
      */
     public static IDoorMovement getMovement(Class<? extends IDoorMovement> clazz) {
-        for (IDoorMovement mvt : movements.values()) if (mvt.getClass().equals(clazz)) return mvt;
+        for (IDoorMovement mvt : movements.values()) if (mvt.getClass()
+            .equals(clazz)) return mvt;
 
         throw new IllegalArgumentException(
-                String.format("Door movement %s not found in the registry", clazz.getSimpleName()));
+            String.format("Door movement %s not found in the registry", clazz.getSimpleName()));
     }
 
     /**
@@ -151,7 +152,10 @@ public class DoorRegistry {
         }
 
         throw new IllegalArgumentException(
-                String.format("Door movement %s not found in the registry", movement.getClass().getSimpleName()));
+            String.format(
+                "Door movement %s not found in the registry",
+                movement.getClass()
+                    .getSimpleName()));
     }
 
     public static Map<String, IDoorMovement> listMovements() {
@@ -174,10 +178,11 @@ public class DoorRegistry {
      * @return
      */
     public static IDoorSound getSound(Class<? extends IDoorSound> clazz) {
-        for (IDoorSound snd : sounds.values()) if (snd.getClass().equals(clazz)) return snd;
+        for (IDoorSound snd : sounds.values()) if (snd.getClass()
+            .equals(clazz)) return snd;
 
         throw new IllegalArgumentException(
-                String.format("Door sound %s not found in the registry", clazz.getSimpleName()));
+            String.format("Door sound %s not found in the registry", clazz.getSimpleName()));
     }
 
     /**
@@ -215,7 +220,10 @@ public class DoorRegistry {
         }
 
         throw new IllegalArgumentException(
-                String.format("Door sound %s not found in the registry", Sound.getClass().getSimpleName()));
+            String.format(
+                "Door sound %s not found in the registry",
+                Sound.getClass()
+                    .getSimpleName()));
     }
 
     public static Map<String, IDoorSound> listSounds() {

--- a/src/main/java/net/malisis/doors/door/block/BigDoor.java
+++ b/src/main/java/net/malisis/doors/door/block/BigDoor.java
@@ -86,8 +86,10 @@ public class BigDoor extends MalisisBlock implements ITileEntityProvider {
     public boolean canPlaceBlockOnSide(World world, int x, int y, int z, int side) {
         if (side != 1) return false;
 
-        ForgeDirection dir = ForgeDirection.getOrientation(side).getOpposite();
-        return world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ).isSideSolid(world, x, y, z, dir);
+        ForgeDirection dir = ForgeDirection.getOrientation(side)
+            .getOpposite();
+        return world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ)
+            .isSideSolid(world, x, y, z, dir);
     }
 
     @Override
@@ -102,7 +104,7 @@ public class BigDoor extends MalisisBlock implements ITileEntityProvider {
 
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX,
-            float hitY, float hitZ) {
+        float hitY, float hitZ) {
         if (world.isRemote) return true;
 
         BigDoorTileEntity te = TileEntityUtils.getTileEntity(BigDoorTileEntity.class, world, x, y, z);
@@ -123,11 +125,11 @@ public class BigDoor extends MalisisBlock implements ITileEntityProvider {
         if (type == BoundingBoxType.RENDER) {
             aabbs[0].minZ = -.5F;
         } else if ((type == BoundingBoxType.COLLISION || type == BoundingBoxType.CHUNKCOLLISION
-                || type == BoundingBoxType.RAYTRACE) && (te.isOpened() || te.isMoving())) {
-                    aabbs = new AxisAlignedBB[] { AxisAlignedBB.getBoundingBox(0, 0, -0.5F, 0.5F, 4, 1),
-                            AxisAlignedBB.getBoundingBox(3.5F, 0, -0.5F, 4, 4, 1),
-                            AxisAlignedBB.getBoundingBox(0, 4, 1 - Door.DOOR_WIDTH, 4, 5, 1) };
-                }
+            || type == BoundingBoxType.RAYTRACE) && (te.isOpened() || te.isMoving())) {
+                aabbs = new AxisAlignedBB[] { AxisAlignedBB.getBoundingBox(0, 0, -0.5F, 0.5F, 4, 1),
+                    AxisAlignedBB.getBoundingBox(3.5F, 0, -0.5F, 4, 4, 1),
+                    AxisAlignedBB.getBoundingBox(0, 4, 1 - Door.DOOR_WIDTH, 4, 5, 1) };
+            }
 
         return AABBUtils.rotate(aabbs, Door.intToDir(te.getDirection()));
     }

--- a/src/main/java/net/malisis/doors/door/block/CustomDoor.java
+++ b/src/main/java/net/malisis/doors/door/block/CustomDoor.java
@@ -141,7 +141,8 @@ public class CustomDoor extends Door {
         if (blocks[i] == null) blocks[i] = Blocks.planks;
 
         EntityDiggingFX fx = new EntityDiggingFX(world, fxX, fxY, fxZ, 0.0D, 0.0D, 0.0D, blocks[i], metadata[i]);
-        fx.multiplyVelocity(0.2F).multipleParticleScaleBy(0.6F);
+        fx.multiplyVelocity(0.2F)
+            .multipleParticleScaleBy(0.6F);
         effectRenderer.addEffect(fx);
 
         return true;
@@ -168,15 +169,15 @@ public class CustomDoor extends Door {
                     int l = (i + j + k) % 2;
                     if (blocks[l] == null) blocks[l] = Blocks.planks;
                     fx = new EntityDiggingFX(
-                            world,
-                            fxX,
-                            fxY,
-                            fxZ,
-                            fxX - x - 0.5D,
-                            fxY - y - 0.5D,
-                            fxZ - z - 0.5D,
-                            blocks[l],
-                            metadata[l]);
+                        world,
+                        fxX,
+                        fxY,
+                        fxZ,
+                        fxX - x - 0.5D,
+                        fxY - y - 0.5D,
+                        fxZ - z - 0.5D,
+                        blocks[l],
+                        metadata[l]);
                     effectRenderer.addEffect(fx);
                 }
             }
@@ -191,7 +192,12 @@ public class CustomDoor extends Door {
         if (te == null || te.getFrame() == null) return 0;
 
         return Math.max(
-                Math.max(te.getFrame().getLightValue(), te.getTopMaterial().getLightValue()),
-                te.getBottomMaterial().getLightValue());
+            Math.max(
+                te.getFrame()
+                    .getLightValue(),
+                te.getTopMaterial()
+                    .getLightValue()),
+            te.getBottomMaterial()
+                .getLightValue());
     }
 }

--- a/src/main/java/net/malisis/doors/door/block/Door.java
+++ b/src/main/java/net/malisis/doors/door/block/Door.java
@@ -179,27 +179,33 @@ public class Door extends BlockDoor implements ITileEntityProvider, IBoundingBox
      */
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer p, int par6, float par7, float par8,
-            float par9) {
+        float par9) {
         DoorTileEntity te = getDoor(world, x, y, z);
         if (te == null) return true;
 
         if (te.getDescriptor() == null) return true;
 
-        if (te.getDescriptor().hasCode() && !te.isOpened()) {
+        if (te.getDescriptor()
+            .hasCode() && !te.isOpened()) {
             if (world.isRemote) new DigicodeGui(te).display();
             return true;
         }
 
         if (world.isRemote) return true;
 
-        if (te.getDescriptor().requireRedstone()) return true;
+        if (te.getDescriptor()
+            .requireRedstone()) return true;
 
-        if (te.getDescriptor().getAutoCloseTime() > 0 && !te.isOpened()) world.scheduleBlockUpdate(
+        if (te.getDescriptor()
+            .getAutoCloseTime() > 0 && !te.isOpened()) world.scheduleBlockUpdate(
                 x,
                 y,
                 z,
                 this,
-                te.getDescriptor().getAutoCloseTime() + te.getDescriptor().getOpeningTime());
+                te.getDescriptor()
+                    .getAutoCloseTime()
+                    + te.getDescriptor()
+                        .getOpeningTime());
 
         te.openOrCloseDoor();
 
@@ -214,9 +220,11 @@ public class Door extends BlockDoor implements ITileEntityProvider, IBoundingBox
         DoorTileEntity te = getDoor(world, x, y, z);
         if (te == null) return;
 
-        if (te.getDescriptor().hasCode()) return;
+        if (te.getDescriptor()
+            .hasCode()) return;
 
-        if (te.getDescriptor().requireRedstone()) return;
+        if (te.getDescriptor()
+            .requireRedstone()) return;
 
         if (opening && te.isOpened()) return;
 
@@ -248,7 +256,8 @@ public class Door extends BlockDoor implements ITileEntityProvider, IBoundingBox
                 DoorTileEntity te = getDoor(world, x, y, z);
                 if (te == null) return;
 
-                if (te.getDescriptor() != null && te.getDescriptor().hasCode()) return;
+                if (te.getDescriptor() != null && te.getDescriptor()
+                    .hasCode()) return;
 
                 boolean powered = te.isPowered();
                 if ((powered || block.canProvidePower()) && block != this) te.setPowered(powered);
@@ -295,7 +304,8 @@ public class Door extends BlockDoor implements ITileEntityProvider, IBoundingBox
         DoorTileEntity te = getDoor(world, x, y, z);
         if (te == null || te.isMoving() || te.getMovement() == null) return new AxisAlignedBB[0];
 
-        AxisAlignedBB aabb = te.getMovement().getBoundingBox(te, te.isTopBlock(x, y, z), type);
+        AxisAlignedBB aabb = te.getMovement()
+            .getBoundingBox(te, te.isTopBlock(x, y, z), type);
         if (aabb != null && te.isCentered()) aabb.offset(0, 0, 0.5F - Door.DOOR_WIDTH / 2);
         AABBUtils.rotate(aabb, intToDir(te.getDirection()));
 
@@ -305,7 +315,7 @@ public class Door extends BlockDoor implements ITileEntityProvider, IBoundingBox
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public void addCollisionBoxesToList(World world, int x, int y, int z, AxisAlignedBB mask, List list,
-            Entity entity) {
+        Entity entity) {
         for (AxisAlignedBB aabb : getBoundingBox(world, x, y, z, BoundingBoxType.COLLISION)) {
             if (aabb != null && mask.intersectsWith(aabb.offset(x, y, z))) list.add(aabb);
         }
@@ -330,7 +340,8 @@ public class Door extends BlockDoor implements ITileEntityProvider, IBoundingBox
         DoorTileEntity te = getDoor(world, x, y, z);
         if (te == null) return;
 
-        if (te.getDescriptor().getAutoCloseTime() <= 0) return;
+        if (te.getDescriptor()
+            .getAutoCloseTime() <= 0) return;
 
         if (te.getState() == DoorState.CLOSED || te.getState() == DoorState.CLOSING) return;
 
@@ -350,7 +361,8 @@ public class Door extends BlockDoor implements ITileEntityProvider, IBoundingBox
 
         DoorTileEntity te;
         try {
-            te = descriptor.getTileEntityClass().newInstance();
+            te = descriptor.getTileEntityClass()
+                .newInstance();
         } catch (InstantiationException | IllegalAccessException e) {
             te = new DoorTileEntity();
         }

--- a/src/main/java/net/malisis/doors/door/block/FenceGate.java
+++ b/src/main/java/net/malisis/doors/door/block/FenceGate.java
@@ -84,15 +84,15 @@ public class FenceGate extends BlockFenceGate implements ITileEntityProvider {
     public FenceGate register() {
         GameRegistry.registerBlock(this, type.name);
         if (type == Type.CAMO) GameRegistry
-                .addRecipe(new ItemStack(this), "ABC", 'A', acaciaFenceGate, 'B', jungleFenceGate, 'C', birchFenceGate);
+            .addRecipe(new ItemStack(this), "ABC", 'A', acaciaFenceGate, 'B', jungleFenceGate, 'C', birchFenceGate);
         else GameRegistry.addRecipe(
-                new ItemStack(this),
-                "ABA",
-                "ABA",
-                'A',
-                Items.stick,
-                'B',
-                new ItemStack(Blocks.planks, 1, type.type));
+            new ItemStack(this),
+            "ABA",
+            "ABA",
+            'A',
+            Items.stick,
+            'B',
+            new ItemStack(Blocks.planks, 1, type.type));
         return this;
     }
 
@@ -133,7 +133,7 @@ public class FenceGate extends BlockFenceGate implements ITileEntityProvider {
      */
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX,
-            float hitY, float hitZ) {
+        float hitY, float hitZ) {
         if (world.isRemote) return true;
 
         DoorTileEntity te = Door.getDoor(world, x, y, z);

--- a/src/main/java/net/malisis/doors/door/block/ForcefieldDoor.java
+++ b/src/main/java/net/malisis/doors/door/block/ForcefieldDoor.java
@@ -58,8 +58,10 @@ public class ForcefieldDoor extends Block implements ITileEntityProvider {
     public boolean canPlaceBlockOnSide(World world, int x, int y, int z, int side) {
         if (side != 1) return false;
 
-        ForgeDirection dir = ForgeDirection.getOrientation(side).getOpposite();
-        return world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ).isSideSolid(world, x, y, z, dir);
+        ForgeDirection dir = ForgeDirection.getOrientation(side)
+            .getOpposite();
+        return world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ)
+            .isSideSolid(world, x, y, z, dir);
     }
 
     @Override
@@ -74,7 +76,7 @@ public class ForcefieldDoor extends Block implements ITileEntityProvider {
 
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX,
-            float hitY, float hitZ) {
+        float hitY, float hitZ) {
         if (world.isRemote) return true;
 
         if (!EntityUtils.isEquipped(player, MalisisDoors.Items.forcefieldItem)) return true;
@@ -94,12 +96,12 @@ public class ForcefieldDoor extends Block implements ITileEntityProvider {
         if (aabb == null) return null;
 
         setBlockBounds(
-                (float) aabb.minX,
-                (float) aabb.minY,
-                (float) aabb.minZ,
-                (float) aabb.maxX,
-                (float) aabb.maxY,
-                (float) aabb.maxZ);
+            (float) aabb.minX,
+            (float) aabb.minY,
+            (float) aabb.minZ,
+            (float) aabb.maxX,
+            (float) aabb.maxY,
+            (float) aabb.maxZ);
         return aabb;
     }
 
@@ -112,7 +114,8 @@ public class ForcefieldDoor extends Block implements ITileEntityProvider {
         }
         if (te.isMoving()) return;
 
-        AxisAlignedBB aabb = te.getMovement().getBoundingBox(te, false, BoundingBoxType.RAYTRACE);
+        AxisAlignedBB aabb = te.getMovement()
+            .getBoundingBox(te, false, BoundingBoxType.RAYTRACE);
         if (aabb == null) aabb = AxisAlignedBB.getBoundingBox(0, 0, 0, 0, 0, 0);
         // aabb = AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 1, 1);
         aabb.offset(-x, -y, -z);
@@ -126,7 +129,8 @@ public class ForcefieldDoor extends Block implements ITileEntityProvider {
         if (te == null || te.getMovement() == null) return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 1, 1);
         if (te.isMoving()) return AxisAlignedBB.getBoundingBox(0, 0, 0, 0, 0, 0);
 
-        AxisAlignedBB aabb = te.getMovement().getBoundingBox(te, false, BoundingBoxType.SELECTION);
+        AxisAlignedBB aabb = te.getMovement()
+            .getBoundingBox(te, false, BoundingBoxType.SELECTION);
         if (aabb == null) return AxisAlignedBB.getBoundingBox(0, 0, 0, 0, 0, 0);
 
         return aabb;
@@ -138,7 +142,8 @@ public class ForcefieldDoor extends Block implements ITileEntityProvider {
         if (te == null || te.getMovement() == null) return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 1, 1);
         if (te.isMoving()) return null;
 
-        AxisAlignedBB aabb = te.getMovement().getBoundingBox(te, false, BoundingBoxType.COLLISION);
+        AxisAlignedBB aabb = te.getMovement()
+            .getBoundingBox(te, false, BoundingBoxType.COLLISION);
         if (aabb == null) return null;
 
         return setBlockBounds(aabb);

--- a/src/main/java/net/malisis/doors/door/block/RustyHatch.java
+++ b/src/main/java/net/malisis/doors/door/block/RustyHatch.java
@@ -71,13 +71,15 @@ public class RustyHatch extends MalisisBlock implements ITileEntityProvider {
     public boolean canPlaceBlockOnSide(World world, int x, int y, int z, int side) {
         if (side == 0 || side == 1) return false;
 
-        ForgeDirection dir = ForgeDirection.getOrientation(side).getOpposite();
-        return world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ).isSideSolid(world, x, y, z, dir);
+        ForgeDirection dir = ForgeDirection.getOrientation(side)
+            .getOpposite();
+        return world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ)
+            .isSideSolid(world, x, y, z, dir);
     }
 
     @Override
     public int onBlockPlaced(World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ,
-            int metadata) {
+        int metadata) {
         return (side - 2) | (hitY > 0.5F ? Door.FLAG_TOPBLOCK : 0);
     }
 
@@ -95,7 +97,7 @@ public class RustyHatch extends MalisisBlock implements ITileEntityProvider {
 
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX,
-            float hitY, float hitZ) {
+        float hitY, float hitZ) {
         if (world.isRemote) return true;
 
         RustyHatchTileEntity te = TileEntityUtils.getTileEntity(RustyHatchTileEntity.class, world, x, y, z);
@@ -118,7 +120,8 @@ public class RustyHatch extends MalisisBlock implements ITileEntityProvider {
         if (te == null || te.isMoving() || te.getMovement() == null || te.getMultiBlock() == null)
             return AABBUtils.identities();
 
-        AxisAlignedBB aabb = te.getMovement().getBoundingBox(te, te.isTopBlock(x, y, z), type);
+        AxisAlignedBB aabb = te.getMovement()
+            .getBoundingBox(te, te.isTopBlock(x, y, z), type);
         if (aabb != null) aabb.offset(-x, -y, -z);
         return new AxisAlignedBB[] { aabb };
     }

--- a/src/main/java/net/malisis/doors/door/block/SaloonDoorBlock.java
+++ b/src/main/java/net/malisis/doors/door/block/SaloonDoorBlock.java
@@ -45,7 +45,7 @@ public class SaloonDoorBlock extends Door {
 
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer p, int par6, float par7, float par8,
-            float par9) {
+        float par9) {
         return true;
     }
 

--- a/src/main/java/net/malisis/doors/door/item/CustomDoorItem.java
+++ b/src/main/java/net/malisis/doors/door/item/CustomDoorItem.java
@@ -67,7 +67,7 @@ public class CustomDoorItem extends DoorItem {
 
     @Override
     public boolean onItemUse(ItemStack itemStack, EntityPlayer player, World world, int x, int y, int z, int side,
-            float par8, float par9, float par10) {
+        float par8, float par9, float par10) {
         boolean b = super.onItemUse(itemStack, player, world, x, y, z, side, par8, par9, par10);
         // if (b)
         // {
@@ -86,8 +86,7 @@ public class CustomDoorItem extends DoorItem {
         ItemStack topMaterialItemStack = te.topMaterialSlot.getItemStack();
         ItemStack bottomMaterialItemStack = te.bottomMaterialSlot.getItemStack();
         if (!canBeUsedForDoor(frameItemStack, true) || !canBeUsedForDoor(topMaterialItemStack, false)
-                || !canBeUsedForDoor(bottomMaterialItemStack, false))
-            return null;
+            || !canBeUsedForDoor(bottomMaterialItemStack, false)) return null;
 
         // frame
         Block frameBlock = Block.getBlockFromItem(frameItemStack.getItem());
@@ -100,7 +99,7 @@ public class CustomDoorItem extends DoorItem {
         int topMaterialMetadata = topMaterialItemStack.getItemDamage();
         if (topMaterialItemStack.getItem() instanceof ItemBlock)
             topMaterialMetadata = ((ItemBlock) topMaterialItemStack.getItem())
-                    .getMetadata(topMaterialItemStack.getItemDamage());
+                .getMetadata(topMaterialItemStack.getItemDamage());
 
         // bottom material
         Block bottomMaterialBlock = itemsAllowed.get(bottomMaterialItemStack.getItem());
@@ -110,12 +109,13 @@ public class CustomDoorItem extends DoorItem {
         int bottomMaterialMetadata = bottomMaterialItemStack.getItemDamage();
         if (bottomMaterialItemStack.getItem() instanceof ItemBlock)
             bottomMaterialMetadata = ((ItemBlock) bottomMaterialItemStack.getItem())
-                    .getMetadata(bottomMaterialItemStack.getItemDamage());
+                .getMetadata(bottomMaterialItemStack.getItemDamage());
 
         // NBT
         NBTTagCompound nbt = new NBTTagCompound();
 
-        te.buildDescriptor().writeNBT(nbt);
+        te.buildDescriptor()
+            .writeNBT(nbt);
 
         nbt.setInteger("frame", Block.getIdFromBlock(frameBlock));
         nbt.setInteger("topMaterial", Block.getIdFromBlock(topMaterialBlock));
@@ -133,7 +133,8 @@ public class CustomDoorItem extends DoorItem {
     public static ItemStack fromTileEntity(CustomDoorTileEntity te) {
         NBTTagCompound nbt = new NBTTagCompound();
 
-        if (te.getDescriptor() != null) te.getDescriptor().writeNBT(nbt);
+        if (te.getDescriptor() != null) te.getDescriptor()
+            .writeNBT(nbt);
 
         nbt.setInteger("frame", Block.getIdFromBlock(te.getFrame()));
         nbt.setInteger("topMaterial", Block.getIdFromBlock(te.getTopMaterial()));
@@ -183,8 +184,8 @@ public class CustomDoorItem extends DoorItem {
         ItemStack isBottomMaterial = new ItemStack(bottomMaterial, 0, bottomMaterialMetadata);
 
         list.add(
-                EnumChatFormatting.WHITE + StatCollector
-                        .translateToLocal("door_movement." + itemStack.stackTagCompound.getString("movement")));
+            EnumChatFormatting.WHITE
+                + StatCollector.translateToLocal("door_movement." + itemStack.stackTagCompound.getString("movement")));
         list.addAll(isFrame.getTooltip(player, advancedTooltip));
         list.addAll(istopMaterial.getTooltip(player, advancedTooltip));
         list.addAll(isBottomMaterial.getTooltip(player, advancedTooltip));

--- a/src/main/java/net/malisis/doors/door/item/DoorItem.java
+++ b/src/main/java/net/malisis/doors/door/item/DoorItem.java
@@ -57,7 +57,7 @@ public class DoorItem extends ItemDoor {
 
     @Override
     public boolean onItemUse(ItemStack itemStack, EntityPlayer player, World world, int x, int y, int z, int side,
-            float par8, float par9, float par10) {
+        float par8, float par9, float par10) {
         if (side != 1) return false;
 
         y++;

--- a/src/main/java/net/malisis/doors/door/item/ForcefieldItem.java
+++ b/src/main/java/net/malisis/doors/door/item/ForcefieldItem.java
@@ -66,9 +66,9 @@ public class ForcefieldItem extends Item {
 
         ForgeDirection dir = ForgeDirection.getOrientation(mop.sideHit);
         ChunkPosition pos = new ChunkPosition(
-                mop.blockX + dir.offsetX,
-                mop.blockY + dir.offsetY,
-                mop.blockZ + dir.offsetZ);
+            mop.blockX + dir.offsetX,
+            mop.blockY + dir.offsetY,
+            mop.blockZ + dir.offsetZ);
         ChunkPosition start = getStartPosition(itemStack);
         if (start.chunkPosY > pos.chunkPosY) {
             ChunkPosition tmp = start;
@@ -116,7 +116,7 @@ public class ForcefieldItem extends Item {
 
     @Override
     public boolean onItemUse(ItemStack itemStack, EntityPlayer player, World world, int x, int y, int z, int side,
-            float hitX, float hitY, float hitZ) {
+        float hitX, float hitY, float hitZ) {
         if (getEnergy(itemStack) < getMaxEnergy()) return true;
 
         ForgeDirection dir = ForgeDirection.getOrientation(side);
@@ -173,9 +173,9 @@ public class ForcefieldItem extends Item {
 
     protected ChunkPosition getStartPosition(ItemStack itemStack) {
         return new ChunkPosition(
-                getNBT(itemStack).getInteger("x"),
-                getNBT(itemStack).getInteger("y"),
-                getNBT(itemStack).getInteger("z"));
+            getNBT(itemStack).getInteger("x"),
+            getNBT(itemStack).getInteger("y"),
+            getNBT(itemStack).getInteger("z"));
     }
 
     protected void clearStartPosition(ItemStack itemStack) {

--- a/src/main/java/net/malisis/doors/door/movement/CarriageDoorMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/CarriageDoorMovement.java
@@ -49,9 +49,12 @@ public class CarriageDoorMovement implements IDoorMovement {
             angle = -angle;
         }
 
-        Rotation rotation = new Rotation(angle).aroundAxis(0, 1, 0).offset(fx, 0, fz);
+        Rotation rotation = new Rotation(angle).aroundAxis(0, 1, 0)
+            .offset(fx, 0, fz);
         rotation.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
-        rotation.forTicks(tileEntity.getDescriptor().getOpeningTime());
+        rotation.forTicks(
+            tileEntity.getDescriptor()
+                .getOpeningTime());
 
         return rotation;
     }
@@ -59,7 +62,7 @@ public class CarriageDoorMovement implements IDoorMovement {
     @Override
     public Animation[] getAnimations(DoorTileEntity tileEntity, MalisisModel model, RenderParameters rp) {
         return new Animation[] { new Animation(model.getShape("left"), getRotation(tileEntity, false)),
-                new Animation(model.getShape("right"), getRotation(tileEntity, true)) };
+            new Animation(model.getShape("right"), getRotation(tileEntity, true)) };
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/door/movement/CurtainMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/CurtainMovement.java
@@ -65,7 +65,9 @@ public class CurtainMovement implements IDoorMovement {
 
         Translation translation = new Translation(x, 0, 0);
         translation.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
-        translation.forTicks(tileEntity.getDescriptor().getOpeningTime());
+        translation.forTicks(
+            tileEntity.getDescriptor()
+                .getOpeningTime());
 
         Shape top = model.getShape("top");
         Shape bottom = model.getShape("bottom");

--- a/src/main/java/net/malisis/doors/door/movement/DoubleRotateMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/DoubleRotateMovement.java
@@ -56,7 +56,8 @@ public class DoubleRotateMovement implements IDoorMovement {
 
     private Transformation getTransformation(DoorTileEntity tileEntity) {
         boolean reversed = tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED;
-        int ot = tileEntity.getDescriptor().getOpeningTime();
+        int ot = tileEntity.getDescriptor()
+            .getOpeningTime();
         float angle = 90;
         float hingeX = 0.5F - DOOR_WIDTH / 2;
         float hingeZ = -0.5F + DOOR_WIDTH / 2;
@@ -72,14 +73,16 @@ public class DoubleRotateMovement implements IDoorMovement {
         }
 
         Rotation rotation = new Rotation(angle);
-        rotation.aroundAxis(0, 1, 0).offset(hingeX, 0, hingeZ);
+        rotation.aroundAxis(0, 1, 0)
+            .offset(hingeX, 0, hingeZ);
         rotation.reversed(reversed);
         rotation.forTicks(ot);
 
         if (tileEntity.isReversed() != rightDirection) {
             float x = 2 - DOOR_WIDTH;
             if (rightDirection) x *= -1;
-            Translation translation = new Translation(0, 0, 0, x, 0, 0).reversed(reversed).forTicks(ot);
+            Translation translation = new Translation(0, 0, 0, x, 0, 0).reversed(reversed)
+                .forTicks(ot);
             return new ParallelTransformation(translation, rotation).forTicks(ot);
         }
 

--- a/src/main/java/net/malisis/doors/door/movement/DoubleSlideMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/DoubleSlideMovement.java
@@ -59,7 +59,9 @@ public class DoubleSlideMovement implements IDoorMovement {
 
         Translation translation = new Translation(0, 0, 0, x, 0, 0);
         translation.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
-        translation.forTicks(tileEntity.getDescriptor().getOpeningTime());
+        translation.forTicks(
+            tileEntity.getDescriptor()
+                .getOpeningTime());
 
         return translation;
     }

--- a/src/main/java/net/malisis/doors/door/movement/FenceGateMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/FenceGateMovement.java
@@ -49,9 +49,12 @@ public class FenceGateMovement implements IDoorMovement {
             hinge = -hinge;
         }
 
-        Rotation rotation = new Rotation(angle).aroundAxis(0, 1, 0).offset(hinge, 0, 0);
+        Rotation rotation = new Rotation(angle).aroundAxis(0, 1, 0)
+            .offset(hinge, 0, 0);
         rotation.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
-        rotation.forTicks(tileEntity.getDescriptor().getOpeningTime());
+        rotation.forTicks(
+            tileEntity.getDescriptor()
+                .getOpeningTime());
 
         return rotation;
     }
@@ -68,7 +71,7 @@ public class FenceGateMovement implements IDoorMovement {
         }
 
         return new Animation[] { new Animation(model.getShape("left"), getTransformation(tileEntity, true)),
-                new Animation(model.getShape("right"), getTransformation(tileEntity, false)) };
+            new Animation(model.getShape("right"), getTransformation(tileEntity, false)) };
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/door/movement/IDoorMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/IDoorMovement.java
@@ -26,9 +26,9 @@ import net.minecraft.util.AxisAlignedBB;
  */
 public interface IDoorMovement {
 
-    public AxisAlignedBB getBoundingBox(DoorTileEntity tileEntity, boolean topBlock, BoundingBoxType type);
+    AxisAlignedBB getBoundingBox(DoorTileEntity tileEntity, boolean topBlock, BoundingBoxType type);
 
-    public Animation[] getAnimations(DoorTileEntity tileEntity, MalisisModel model, RenderParameters rp);
+    Animation[] getAnimations(DoorTileEntity tileEntity, MalisisModel model, RenderParameters rp);
 
-    public boolean isSpecial();
+    boolean isSpecial();
 }

--- a/src/main/java/net/malisis/doors/door/movement/RotateAndPlaceMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/RotateAndPlaceMovement.java
@@ -51,7 +51,8 @@ public class RotateAndPlaceMovement implements IDoorMovement {
     }
 
     private Transformation getTransformation(DoorTileEntity tileEntity) {
-        int ot = tileEntity.getDescriptor().getOpeningTime() / 2;
+        int ot = tileEntity.getDescriptor()
+            .getOpeningTime() / 2;
         float angle = 90;
         float hinge = 0;
         float hingeZ = -0.5F;
@@ -64,12 +65,14 @@ public class RotateAndPlaceMovement implements IDoorMovement {
             trX = -trX;
         }
 
-        Transformation rotation = new Rotation(angle).aroundAxis(0, 1, 0).offset(hinge, 0, hingeZ).forTicks(ot);
+        Transformation rotation = new Rotation(angle).aroundAxis(0, 1, 0)
+            .offset(hinge, 0, hingeZ)
+            .forTicks(ot);
         Transformation translation = new Translation(0, 0, trZ).forTicks(ot);
 
         Transformation transformation = new ChainedTransformation(rotation, translation);
         transformation
-                .reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
+            .reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
 
         return transformation;
     }

--- a/src/main/java/net/malisis/doors/door/movement/RotateAndSlideMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/RotateAndSlideMovement.java
@@ -48,7 +48,8 @@ public class RotateAndSlideMovement implements IDoorMovement {
     }
 
     private Transformation getTransformation(DoorTileEntity tileEntity) {
-        int ot = tileEntity.getDescriptor().getOpeningTime() / 2;
+        int ot = tileEntity.getDescriptor()
+            .getOpeningTime() / 2;
         float angle = -90;
         float hinge = 0.5F - DOOR_WIDTH / 2;
         float hingeZ = -0.5F + DOOR_WIDTH / 2;
@@ -60,12 +61,14 @@ public class RotateAndSlideMovement implements IDoorMovement {
             tr = -tr;
         }
 
-        Transformation rotation = new Rotation(angle).aroundAxis(0, 1, 0).offset(hinge, 0, hingeZ).forTicks(ot);
+        Transformation rotation = new Rotation(angle).aroundAxis(0, 1, 0)
+            .offset(hinge, 0, hingeZ)
+            .forTicks(ot);
         Transformation translation = new Translation(tr, 0, 0).forTicks(ot);
 
         Transformation transformation = new ChainedTransformation(rotation, translation);
         transformation
-                .reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
+            .reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
 
         return transformation;
     }

--- a/src/main/java/net/malisis/doors/door/movement/RotateAroundMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/RotateAroundMovement.java
@@ -51,9 +51,11 @@ public class RotateAroundMovement implements IDoorMovement {
 
         Transformation transformation = new Rotation(angle).aroundAxis(0, 1, 0);
         transformation
-                .reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
+            .reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
 
-        return transformation.forTicks(tileEntity.getDescriptor().getOpeningTime());
+        return transformation.forTicks(
+            tileEntity.getDescriptor()
+                .getOpeningTime());
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/door/movement/Rotating4WaysMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/Rotating4WaysMovement.java
@@ -74,9 +74,12 @@ public class Rotating4WaysMovement implements IDoorMovement {
         }
 
         Rotation rotation = new Rotation(angle);
-        rotation.aroundAxis(axisX, axisY, 0).offset(hingeX, hingeY, hingeZ);;
+        rotation.aroundAxis(axisX, axisY, 0)
+            .offset(hingeX, hingeY, hingeZ);;
         rotation.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
-        rotation.forTicks(tileEntity.getDescriptor().getOpeningTime());
+        rotation.forTicks(
+            tileEntity.getDescriptor()
+                .getOpeningTime());
 
         return rotation;
     }
@@ -84,7 +87,7 @@ public class Rotating4WaysMovement implements IDoorMovement {
     @Override
     public Animation[] getAnimations(DoorTileEntity tileEntity, MalisisModel model, RenderParameters rp) {
         return new Animation[] { new Animation(model.getShape("top"), getTransformation(tileEntity, true)),
-                new Animation(model.getShape("bottom"), getTransformation(tileEntity, false)) };
+            new Animation(model.getShape("bottom"), getTransformation(tileEntity, false)) };
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/door/movement/RotatingDoorMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/RotatingDoorMovement.java
@@ -56,9 +56,12 @@ public class RotatingDoorMovement implements IDoorMovement {
         }
 
         Rotation rotation = new Rotation(angle);
-        rotation.aroundAxis(0, 1, 0).offset(hingeX, 0, hingeZ);
+        rotation.aroundAxis(0, 1, 0)
+            .offset(hingeX, 0, hingeZ);
         rotation.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
-        rotation.forTicks(tileEntity.getDescriptor().getOpeningTime());
+        rotation.forTicks(
+            tileEntity.getDescriptor()
+                .getOpeningTime());
 
         return rotation;
     }

--- a/src/main/java/net/malisis/doors/door/movement/RotatingSplitMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/RotatingSplitMovement.java
@@ -58,9 +58,12 @@ public class RotatingSplitMovement implements IDoorMovement {
             hingeY = 1 - hingeY;
         }
 
-        Rotation rotation = new Rotation(angle).aroundAxis(1, 0, 0).offset(0, hingeY, hingeZ);
+        Rotation rotation = new Rotation(angle).aroundAxis(1, 0, 0)
+            .offset(0, hingeY, hingeZ);
         rotation.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
-        rotation.forTicks(tileEntity.getDescriptor().getOpeningTime());
+        rotation.forTicks(
+            tileEntity.getDescriptor()
+                .getOpeningTime());
 
         return rotation;
     }
@@ -68,7 +71,7 @@ public class RotatingSplitMovement implements IDoorMovement {
     @Override
     public Animation[] getAnimations(DoorTileEntity tileEntity, MalisisModel model, RenderParameters rp) {
         return new Animation[] { new Animation(model.getShape("top"), getTransformation(tileEntity, true)),
-                new Animation(model.getShape("bottom"), getTransformation(tileEntity, false)) };
+            new Animation(model.getShape("bottom"), getTransformation(tileEntity, false)) };
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/door/movement/RustyHatchMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/RustyHatchMovement.java
@@ -87,9 +87,11 @@ public class RustyHatchMovement implements IDoorMovement {
             offY = -0.5F;
         }
 
-        int t = tileEntity.getDescriptor().getOpeningTime() / 2;
-        Rotation rotation = new Rotation(toAngle).aroundAxis(0, 0, 1).offset(offX, offY, 0)
-                .movement(Transformation.SINUSOIDAL);
+        int t = tileEntity.getDescriptor()
+            .getOpeningTime() / 2;
+        Rotation rotation = new Rotation(toAngle).aroundAxis(0, 0, 1)
+            .offset(offX, offY, 0)
+            .movement(Transformation.SINUSOIDAL);
 
         if (tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED)
             rotation.reversed(true);
@@ -100,11 +102,13 @@ public class RustyHatchMovement implements IDoorMovement {
     }
 
     private Transformation getHandleTransformation(DoorTileEntity tileEntity) {
-        int t = tileEntity.getDescriptor().getOpeningTime() / 2;
-        Rotation rotation = new Rotation(400).aroundAxis(0, 1, 0).offset(0.5F, 0, 0.5F)
-                .movement(Transformation.SINUSOIDAL);
-        if (tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED)
-            rotation.delay(t).reversed(true);
+        int t = tileEntity.getDescriptor()
+            .getOpeningTime() / 2;
+        Rotation rotation = new Rotation(400).aroundAxis(0, 1, 0)
+            .offset(0.5F, 0, 0.5F)
+            .movement(Transformation.SINUSOIDAL);
+        if (tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED) rotation.delay(t)
+            .reversed(true);
         rotation.forTicks(t);
 
         return rotation;
@@ -113,10 +117,10 @@ public class RustyHatchMovement implements IDoorMovement {
     @Override
     public Animation[] getAnimations(DoorTileEntity tileEntity, MalisisModel model, RenderParameters rp) {
         Transformation transform = new ParallelTransformation(
-                getDoorTransformation(tileEntity),
-                getHandleTransformation(tileEntity));
+            getDoorTransformation(tileEntity),
+            getHandleTransformation(tileEntity));
         return new Animation[] { new Animation(model.getShape("door"), getDoorTransformation(tileEntity)),
-                new Animation(model.getShape("handle"), transform) };
+            new Animation(model.getShape("handle"), transform) };
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/door/movement/SaloonDoorMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/SaloonDoorMovement.java
@@ -56,27 +56,32 @@ public class SaloonDoorMovement implements IDoorMovement {
 
         if (((SaloonDoorTileEntity) tileEntity).isBackward()) angle = -angle;
 
-        int t = tileEntity.getDescriptor().getOpeningTime() / 4;
+        int t = tileEntity.getDescriptor()
+            .getOpeningTime() / 4;
         Rotation r1 = new Rotation(angle);
-        r1.aroundAxis(0, 1, 0).offset(hingeX, 0, 0);
+        r1.aroundAxis(0, 1, 0)
+            .offset(hingeX, 0, 0);
         r1.movement(Transformation.SINUSOIDAL);
         // r1.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
         r1.forTicks(t);
 
         Rotation r2 = new Rotation(-angle * 1.5F);
-        r2.aroundAxis(0, 1, 0).offset(hingeX, 0, 0);
+        r2.aroundAxis(0, 1, 0)
+            .offset(hingeX, 0, 0);
         r2.movement(Transformation.SINUSOIDAL);
         // r1.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
         r2.forTicks(t);
 
         Rotation r3 = new Rotation(angle * .75F);
-        r3.aroundAxis(0, 1, 0).offset(hingeX, 0, 0);
+        r3.aroundAxis(0, 1, 0)
+            .offset(hingeX, 0, 0);
         r3.movement(Transformation.SINUSOIDAL);
         // r1.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
         r3.forTicks(t);
 
         Rotation r4 = new Rotation(-angle * .25F);
-        r4.aroundAxis(0, 1, 0).offset(hingeX, 0, 0);
+        r4.aroundAxis(0, 1, 0)
+            .offset(hingeX, 0, 0);
         r4.movement(Transformation.SINUSOIDAL);
         // r1.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
         r4.forTicks(t);

--- a/src/main/java/net/malisis/doors/door/movement/Sliding4WaysMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/Sliding4WaysMovement.java
@@ -61,7 +61,9 @@ public class Sliding4WaysMovement implements IDoorMovement {
 
         Translation translation = new Translation(toX, toY, 0);
         translation.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
-        translation.forTicks(tileEntity.getDescriptor().getOpeningTime());
+        translation.forTicks(
+            tileEntity.getDescriptor()
+                .getOpeningTime());
 
         return translation;
     }
@@ -69,7 +71,7 @@ public class Sliding4WaysMovement implements IDoorMovement {
     @Override
     public Animation[] getAnimations(DoorTileEntity tileEntity, MalisisModel model, RenderParameters rp) {
         return new Animation[] { new Animation(model.getShape("top"), getTransformation(tileEntity, true)),
-                new Animation(model.getShape("bottom"), getTransformation(tileEntity, false)) };
+            new Animation(model.getShape("bottom"), getTransformation(tileEntity, false)) };
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/door/movement/SlidingDoorMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/SlidingDoorMovement.java
@@ -47,14 +47,16 @@ public class SlidingDoorMovement implements IDoorMovement {
 
     private Transformation getTransformation(DoorTileEntity tileEntity) {
         Translation translation = new Translation(
-                0,
-                0,
-                0,
-                tileEntity.isReversed() ? -1 + Door.DOOR_WIDTH : 1 - DOOR_WIDTH,
-                0,
-                0);
+            0,
+            0,
+            0,
+            tileEntity.isReversed() ? -1 + Door.DOOR_WIDTH : 1 - DOOR_WIDTH,
+            0,
+            0);
         translation.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
-        translation.forTicks(tileEntity.getDescriptor().getOpeningTime());
+        translation.forTicks(
+            tileEntity.getDescriptor()
+                .getOpeningTime());
 
         return translation;
     }

--- a/src/main/java/net/malisis/doors/door/movement/SlidingSplitDoorMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/SlidingSplitDoorMovement.java
@@ -49,7 +49,9 @@ public class SlidingSplitDoorMovement implements IDoorMovement {
     private Transformation getTransformation(DoorTileEntity tileEntity, boolean top) {
         Translation translation = new Translation(0, 0, 0, 0, top ? 1 - DOOR_WIDTH : -1.1F, 0);
         translation.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
-        translation.forTicks(tileEntity.getDescriptor().getOpeningTime());
+        translation.forTicks(
+            tileEntity.getDescriptor()
+                .getOpeningTime());
 
         return translation;
     }
@@ -57,7 +59,7 @@ public class SlidingSplitDoorMovement implements IDoorMovement {
     @Override
     public Animation[] getAnimations(DoorTileEntity tileEntity, MalisisModel model, RenderParameters rp) {
         return new Animation[] { new Animation(model.getShape("top"), getTransformation(tileEntity, true)),
-                new Animation(model.getShape("bottom"), getTransformation(tileEntity, false)) };
+            new Animation(model.getShape("bottom"), getTransformation(tileEntity, false)) };
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/door/movement/SlidingUpDoorMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/SlidingUpDoorMovement.java
@@ -50,7 +50,9 @@ public class SlidingUpDoorMovement implements IDoorMovement {
     private Transformation getTransformation(DoorTileEntity tileEntity) {
         Translation translation = new Translation(0, 0, 0, 0, 2 - DOOR_WIDTH, 0);
         translation.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
-        translation.forTicks(tileEntity.getDescriptor().getOpeningTime());
+        translation.forTicks(
+            tileEntity.getDescriptor()
+                .getOpeningTime());
 
         return translation;
     }

--- a/src/main/java/net/malisis/doors/door/movement/SpinningAroundDoorMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/SpinningAroundDoorMovement.java
@@ -35,7 +35,8 @@ public class SpinningAroundDoorMovement implements IDoorMovement {
     private Rotation rotBot = new Rotation(720).aroundAxis(0, 0, 1);
     private Rotation rotTop = new Rotation(720).aroundAxis(0, 0, 1);
     private Rotation rotBot2 = new Rotation(-720).aroundAxis(0, 0, 1);
-    private Rotation rotTop2 = new Rotation(-720).aroundAxis(0, 0, 1).offset(0, 1, 0);
+    private Rotation rotTop2 = new Rotation(-720).aroundAxis(0, 0, 1)
+        .offset(0, 1, 0);
     private Scale scaleBot = new Scale(0, 0, 0);
     private Scale scaleTop = new Scale(0, 0, 0).offset(0, 1, 0);
 
@@ -56,7 +57,8 @@ public class SpinningAroundDoorMovement implements IDoorMovement {
     public Animation[] getAnimations(DoorTileEntity tileEntity, MalisisModel model, RenderParameters rp) {
         boolean doubleDoor = tileEntity.getDoubleDoor() != null;
         boolean closed = tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED;
-        int ot = tileEntity.getDescriptor().getOpeningTime();
+        int ot = tileEntity.getDescriptor()
+            .getOpeningTime();
         float offsetX = doubleDoor ? (tileEntity.isReversed() ? 0.5F : -0.5F) : 0;
 
         rotBot.offset(offsetX, 0.5F, 0);
@@ -83,7 +85,7 @@ public class SpinningAroundDoorMovement implements IDoorMovement {
         ParallelTransformation top = new ParallelTransformation(rotTop, rotTop2, scaleTop);
 
         return new Animation[] { new Animation(model.getShape("bottom"), bot),
-                new Animation(model.getShape("top"), top) };
+            new Animation(model.getShape("top"), top) };
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/door/movement/SpinningDoorMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/SpinningDoorMovement.java
@@ -33,7 +33,8 @@ import net.minecraft.util.AxisAlignedBB;
 public class SpinningDoorMovement implements IDoorMovement {
 
     private Rotation rotBot = new Rotation(0).aroundAxis(0, 0, 1);
-    private Rotation rotTop = new Rotation(0).aroundAxis(0, 0, 1).offset(0, 1, 0);
+    private Rotation rotTop = new Rotation(0).aroundAxis(0, 0, 1)
+        .offset(0, 1, 0);
     private Scale scaleBot = new Scale(0, 0, 0);
     private Scale scaleTop = new Scale(0, 0, 0).offset(0, 1, 0);
 
@@ -54,7 +55,8 @@ public class SpinningDoorMovement implements IDoorMovement {
     public Animation[] getAnimations(DoorTileEntity tileEntity, MalisisModel model, RenderParameters rp) {
         float angle = tileEntity.isReversed() ? -720 : 720;
         boolean closed = tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED;
-        int ot = tileEntity.getDescriptor().getOpeningTime();
+        int ot = tileEntity.getDescriptor()
+            .getOpeningTime();
 
         rotBot.from(angle);
         rotBot.reversed(closed);
@@ -74,7 +76,7 @@ public class SpinningDoorMovement implements IDoorMovement {
         ParallelTransformation top = new ParallelTransformation(rotTop, scaleTop);
 
         return new Animation[] { new Animation(model.getShape("bottom"), bot),
-                new Animation(model.getShape("top"), top) };
+            new Animation(model.getShape("top"), top) };
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/door/movement/VanishingDoorMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/VanishingDoorMovement.java
@@ -47,7 +47,9 @@ public class VanishingDoorMovement implements IDoorMovement {
     public Animation[] getAnimations(DoorTileEntity tileEntity, MalisisModel model, RenderParameters rp) {
         AlphaTransform alpha = new AlphaTransform(255, 0);
         alpha.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
-        alpha.forTicks(tileEntity.getDescriptor().getOpeningTime());
+        alpha.forTicks(
+            tileEntity.getDescriptor()
+                .getOpeningTime());
         return new Animation[] { new Animation(rp, alpha) };
     }
 

--- a/src/main/java/net/malisis/doors/door/movement/VaultDoorMovement.java
+++ b/src/main/java/net/malisis/doors/door/movement/VaultDoorMovement.java
@@ -61,9 +61,12 @@ public class VaultDoorMovement implements IDoorMovement {
 
         if (!tileEntity.isReversed()) offsetX = -offsetX;
 
-        Rotation rotation = new Rotation(angle).aroundAxis(0, 0, 1).offset(offsetX, offsetY, 0);
+        Rotation rotation = new Rotation(angle).aroundAxis(0, 0, 1)
+            .offset(offsetX, offsetY, 0);
         rotation.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
-        rotation.forTicks(tileEntity.getDescriptor().getOpeningTime());
+        rotation.forTicks(
+            tileEntity.getDescriptor()
+                .getOpeningTime());
 
         return rotation;
     }
@@ -71,7 +74,7 @@ public class VaultDoorMovement implements IDoorMovement {
     @Override
     public Animation[] getAnimations(DoorTileEntity tileEntity, MalisisModel model, RenderParameters rp) {
         return new Animation[] { new Animation(model.getShape("top"), getTransformation(tileEntity, true)),
-                new Animation(model.getShape("bottom"), getTransformation(tileEntity, false)) };
+            new Animation(model.getShape("bottom"), getTransformation(tileEntity, false)) };
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/door/renderer/BigDoorRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/BigDoorRenderer.java
@@ -79,7 +79,8 @@ public class BigDoorRenderer extends MalisisRenderer {
 
     private void renderBlock() {
         BlockState state = tileEntity.getFrameState();
-        if (!state.getBlock().canRenderInPass(BigDoor.renderPass)) return;
+        if (!state.getBlock()
+            .canRenderInPass(BigDoor.renderPass)) return;
 
         set(state.getBlock(), state.getMetadata());
         // rp.icon.set(state.getBlock().getIcon(1, state.getMetadata()));
@@ -89,10 +90,13 @@ public class BigDoorRenderer extends MalisisRenderer {
     }
 
     private void renderTileEntity() {
-        ar.setStartTime(tileEntity.getTimer().getStart());
+        ar.setStartTime(
+            tileEntity.getTimer()
+                .getStart());
 
         if (tileEntity.getMovement() != null) {
-            Animation[] anims = tileEntity.getMovement().getAnimations(tileEntity, model, rp);
+            Animation[] anims = tileEntity.getMovement()
+                .getAnimations(tileEntity, model, rp);
             ar.animate(anims);
         }
 

--- a/src/main/java/net/malisis/doors/door/renderer/CustomDoorRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/CustomDoorRenderer.java
@@ -48,6 +48,7 @@ public class CustomDoorRenderer extends DoorRenderer {
     private float width;
     private final Cube scratchR = new Cube();
     private final Cube scratchL = new Cube();
+    private final Shape scratchH = new Shape(new NorthFace(), new SouthFace(), new TopFace(), new BottomFace());
 
     @Override
     protected void initialize() {
@@ -63,7 +64,8 @@ public class CustomDoorRenderer extends DoorRenderer {
         Shape frameL = this.scratchL.copy(frameR);
         frameL.translate(1 - width, 0, 0);
         // frame horizontal
-        Shape frameH = new Shape(new NorthFace(), new SouthFace(), new TopFace(), new BottomFace());
+        this.scratchH.reset();
+        Shape frameH = this.scratchH;
         frameH.setSize(1 - 2 * width, width, Door.DOOR_WIDTH);
         frameH.translate(width, 0, 0);
 

--- a/src/main/java/net/malisis/doors/door/renderer/CustomDoorRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/CustomDoorRenderer.java
@@ -46,6 +46,8 @@ public class CustomDoorRenderer extends DoorRenderer {
     protected CustomDoorTileEntity tileEntity;
 
     private float width;
+    private final Cube scratchR = new Cube();
+    private final Cube scratchL = new Cube();
 
     @Override
     protected void initialize() {
@@ -54,9 +56,11 @@ public class CustomDoorRenderer extends DoorRenderer {
          * BOTTOM
          */
         // frame right
-        Shape frameR = new Cube().setSize(width, 1, Door.DOOR_WIDTH);
+        this.scratchR.reset();
+        Cube frameR = (Cube) this.scratchR.setSize(width, 1, Door.DOOR_WIDTH);
         // frame left
-        Shape frameL = new Shape(frameR);
+        this.scratchL.reset();
+        Shape frameL = this.scratchL.copy(frameR);
         frameL.translate(1 - width, 0, 0);
         // frame horizontal
         Shape frameH = new Shape(new NorthFace(), new SouthFace(), new TopFace(), new BottomFace());
@@ -82,7 +86,7 @@ public class CustomDoorRenderer extends DoorRenderer {
         /**
          * TOP
          */
-        frameR = new Shape(frameR);
+        frameR = new Cube(frameR);
         frameL = new Shape(frameL);
         frameH = new Shape(frameH);
         frameH.translate(0, 1 - width, 0);

--- a/src/main/java/net/malisis/doors/door/renderer/CustomDoorRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/CustomDoorRenderer.java
@@ -83,7 +83,8 @@ public class CustomDoorRenderer extends DoorRenderer {
 
         // bottom material
         this.bMat.reset();
-        this.bMat.setSize(1 - 2 * width, 1 - width, Door.DOOR_WIDTH * 0.6F).translate(width, width, Door.DOOR_WIDTH * 0.2F);
+        this.bMat.setSize(1 - 2 * width, 1 - width, Door.DOOR_WIDTH * 0.6F)
+            .translate(width, width, Door.DOOR_WIDTH * 0.2F);
         this.bMat.applyMatrix();
 
         this.bottom.takeFaces(gnames, this.frame, this.bMat);

--- a/src/main/java/net/malisis/doors/door/renderer/CustomDoorRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/CustomDoorRenderer.java
@@ -53,6 +53,7 @@ public class CustomDoorRenderer extends DoorRenderer {
     private final Shape scratchH = new Shape(new NorthFace(), new SouthFace(), new TopFace(), new BottomFace());
     private final Shape scratchH2 = new Shape(new NorthFace(), new SouthFace(), new TopFace(), new BottomFace());
     private final Shape scratchB = new Shape(new SouthFace(), new TopFace(), new NorthFace());
+    private final Shape scratchMat = new Shape(this.scratchB);
 
     @Override
     protected void initialize() {
@@ -94,8 +95,8 @@ public class CustomDoorRenderer extends DoorRenderer {
          * TOP
          */
         frameR = this.scratchR2.copy(frameR);
-        frameL = new Shape(frameL);
-        frameH = new Shape(frameH);
+        frameL = this.scratchL2.copy(frameL);
+        frameH = this.scratchH2.copy(frameH);
         frameH.translate(0, 1 - width, 0);
 
         // full top frame
@@ -104,7 +105,7 @@ public class CustomDoorRenderer extends DoorRenderer {
         frame.applyMatrix();
 
         // top material
-        mat = new Shape(mat);
+        mat = this.scratchMat.copy(mat);
         mat.translate(0, -width, 0);
         mat.applyMatrix();
 

--- a/src/main/java/net/malisis/doors/door/renderer/CustomDoorRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/CustomDoorRenderer.java
@@ -46,14 +46,18 @@ public class CustomDoorRenderer extends DoorRenderer {
     protected CustomDoorTileEntity tileEntity;
 
     private float width;
-    private final Cube scratchR = new Cube();
-    private final Cube scratchR2 = new Cube();
-    private final Cube scratchL = new Cube();
-    private final Cube scratchL2 = new Cube();
-    private final Shape scratchH = new Shape(new NorthFace(), new SouthFace(), new TopFace(), new BottomFace());
-    private final Shape scratchH2 = new Shape(new NorthFace(), new SouthFace(), new TopFace(), new BottomFace());
-    private final Shape scratchB = new Shape(new SouthFace(), new TopFace(), new NorthFace());
-    private final Shape scratchMat = new Shape(this.scratchB);
+    private final Cube bottomR = new Cube();
+    private final Cube bottomL = new Cube();
+    private final Shape bottomH = new Shape(new NorthFace(), new SouthFace(), new TopFace(), new BottomFace());
+    private final Shape bMat = new Shape(new SouthFace(), new TopFace(), new NorthFace());
+    private final Cube topR = new Cube();
+    private final Cube topL = new Cube();
+    private final Shape topH = new Shape(new NorthFace(), new SouthFace(), new TopFace(), new BottomFace());
+    private final Shape tMat = new Shape(this.bMat);
+    private final Shape frame = new Shape();
+    private final Shape bottom = new Shape();
+    private final Shape top = new Shape();
+    private static final String[] gnames = { "frame", "material" };
 
     @Override
     protected void initialize() {
@@ -62,67 +66,62 @@ public class CustomDoorRenderer extends DoorRenderer {
          * BOTTOM
          */
         // frame right
-        this.scratchR.reset();
-        Cube frameR = (Cube) this.scratchR.setSize(width, 1, Door.DOOR_WIDTH);
+        this.bottomR.reset();
+        this.bottomR.setSize(width, 1, Door.DOOR_WIDTH);
         // frame left
-        this.scratchL.reset();
-        Shape frameL = this.scratchL.copy(frameR);
-        frameL.translate(1 - width, 0, 0);
+        this.bottomL.copy(this.bottomR);
+        this.bottomL.translate(1 - width, 0, 0);
         // frame horizontal
-        this.scratchH.reset();
-        Shape frameH = this.scratchH;
-        frameH.setSize(1 - 2 * width, width, Door.DOOR_WIDTH);
-        frameH.translate(width, 0, 0);
+        this.bottomH.reset();
+        this.bottomH.setSize(1 - 2 * width, width, Door.DOOR_WIDTH);
+        this.bottomH.translate(width, 0, 0);
 
         // full bottom frame
-        Shape frame = Shape.fromShapes(frameR, frameL, frameH);
-        frame.scale(1, 1, 0.995F); // scale frame to prevent z-fighting when slid in walls
-        frame.applyMatrix();
+        this.frame.takeShapes(this.bottomR, this.bottomL, this.bottomH);
+        this.frame.scale(1, 1, 0.995F); // scale frame to prevent z-fighting when slid in walls
+        this.frame.applyMatrix();
 
         // bottom material
-        this.scratchB.reset();
-        Shape mat = this.scratchB;
-        mat.setSize(1 - 2 * width, 1 - width, Door.DOOR_WIDTH * 0.6F).translate(width, width, Door.DOOR_WIDTH * 0.2F);
-        mat.applyMatrix();
+        this.bMat.reset();
+        this.bMat.setSize(1 - 2 * width, 1 - width, Door.DOOR_WIDTH * 0.6F).translate(width, width, Door.DOOR_WIDTH * 0.2F);
+        this.bMat.applyMatrix();
 
-        Shape bottom = new Shape();
-        bottom.addFaces(frame.getFaces(), "frame");
-        bottom.addFaces(mat.getFaces(), "material");
-        bottom.interpolateUV();
-        bottom.storeState();
+        this.bottom.takeFaces(gnames, this.frame, this.bMat);
+        this.bottom.interpolateUV();
+        this.bottom.storeState();
 
         /**
          * TOP
          */
-        frameR = this.scratchR2.copy(frameR);
-        frameL = this.scratchL2.copy(frameL);
-        frameH = this.scratchH2.copy(frameH);
-        frameH.translate(0, 1 - width, 0);
+        this.topR.copy(this.bottomR);
+        this.topL.copy(this.bottomL);
+        this.topH.copy(this.bottomH);
+        this.topH.translate(0, 1 - width, 0);
 
         // full top frame
-        frame = Shape.fromShapes(frameR, frameL, frameH);
-        frame.scale(1, 1, 0.995F); // scale frame to prevent z-fighting when slid in walls
-        frame.applyMatrix();
+        this.frame.takeShapes(this.topR, this.topL, this.topH);
+        this.frame.scale(1, 1, 0.995F); // scale frame to prevent z-fighting when slid in walls
+        this.frame.applyMatrix();
 
         // top material
-        mat = this.scratchMat.copy(mat);
-        mat.translate(0, -width, 0);
-        mat.applyMatrix();
+        this.tMat.copy(this.bMat);
+        this.tMat.translate(0, -width, 0);
+        this.tMat.applyMatrix();
 
-        Shape top = new Shape();
-        top.addFaces(frame.getFaces(), "frame");
-        top.addFaces(mat.getFaces(), "material");
+        this.top.takeFaces(gnames, this.frame, this.tMat);
         top.translate(0, 1, 0);
         top.interpolateUV();
         top.storeState();
 
         // store top and bottom inside a model
-        model = new MalisisModel();
-        model.addShape("bottom", bottom);
+        if (this.model != null) this.model.reset();
+        else this.model = new MalisisModel();
+        model.addShape("bottom", this.bottom);
         model.addShape("top", top);
         model.storeState();
 
-        initParams();
+        if (this.rp != null) this.rp.init();
+        else initParams();
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/door/renderer/CustomDoorRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/CustomDoorRenderer.java
@@ -47,8 +47,12 @@ public class CustomDoorRenderer extends DoorRenderer {
 
     private float width;
     private final Cube scratchR = new Cube();
+    private final Cube scratchR2 = new Cube();
     private final Cube scratchL = new Cube();
+    private final Cube scratchL2 = new Cube();
     private final Shape scratchH = new Shape(new NorthFace(), new SouthFace(), new TopFace(), new BottomFace());
+    private final Shape scratchH2 = new Shape(new NorthFace(), new SouthFace(), new TopFace(), new BottomFace());
+    private final Shape scratchB = new Shape(new SouthFace(), new TopFace(), new NorthFace());
 
     @Override
     protected void initialize() {
@@ -75,7 +79,8 @@ public class CustomDoorRenderer extends DoorRenderer {
         frame.applyMatrix();
 
         // bottom material
-        Shape mat = new Shape(new SouthFace(), new NorthFace(), new TopFace());
+        this.scratchB.reset();
+        Shape mat = this.scratchB;
         mat.setSize(1 - 2 * width, 1 - width, Door.DOOR_WIDTH * 0.6F).translate(width, width, Door.DOOR_WIDTH * 0.2F);
         mat.applyMatrix();
 
@@ -88,7 +93,7 @@ public class CustomDoorRenderer extends DoorRenderer {
         /**
          * TOP
          */
-        frameR = new Cube(frameR);
+        frameR = this.scratchR2.copy(frameR);
         frameL = new Shape(frameL);
         frameH = new Shape(frameH);
         frameH.translate(0, 1 - width, 0);

--- a/src/main/java/net/malisis/doors/door/renderer/DoorRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/DoorRenderer.java
@@ -102,12 +102,15 @@ public class DoorRenderer extends MalisisRenderer {
 
     protected void renderTileEntity() {
         enableBlending();
-        ar.setStartTime(tileEntity.getTimer().getStart());
+        ar.setStartTime(
+            tileEntity.getTimer()
+                .getStart());
 
         setup();
 
         if (tileEntity.getMovement() != null) {
-            Animation[] anims = tileEntity.getMovement().getAnimations(tileEntity, model, rp);
+            Animation[] anims = tileEntity.getMovement()
+                .getAnimations(tileEntity, model, rp);
             ar.animate(anims);
         }
 
@@ -125,7 +128,7 @@ public class DoorRenderer extends MalisisRenderer {
     @Override
     protected boolean isCurrentBlockDestroyProgress(DestroyBlockProgress dbp) {
         return dbp.getPartialBlockX() == x && (dbp.getPartialBlockY() == y || dbp.getPartialBlockY() == y + 1)
-                && dbp.getPartialBlockZ() == z;
+            && dbp.getPartialBlockZ() == z;
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/door/renderer/FenceGateRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/FenceGateRenderer.java
@@ -90,12 +90,15 @@ public class FenceGateRenderer extends DoorRenderer {
     @Override
     protected void renderTileEntity() {
         enableBlending();
-        ar.setStartTime(tileEntity.getTimer().getStart());
+        ar.setStartTime(
+            tileEntity.getTimer()
+                .getStart());
 
         setup();
 
         if (tileEntity.getMovement() != null) {
-            Animation[] anims = tileEntity.getMovement().getAnimations(tileEntity, model, rp);
+            Animation[] anims = tileEntity.getMovement()
+                .getAnimations(tileEntity, model, rp);
             ar.animate(anims);
         }
 

--- a/src/main/java/net/malisis/doors/door/renderer/ForcefieldRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/ForcefieldRenderer.java
@@ -46,7 +46,7 @@ public class ForcefieldRenderer extends MalisisRenderer {
     protected void initialize() {
         rl = new ResourceLocation[50];
         for (int i = 0; i < 50; i++) rl[i] = new ResourceLocation(
-                String.format(MalisisDoors.modid + ":textures/blocks/forcefield/forcefield%02d.png", i));
+            String.format(MalisisDoors.modid + ":textures/blocks/forcefield/forcefield%02d.png", i));
 
         Shape shape = new Shape(new NorthFace());
         shape.scale(1, 1, 0);
@@ -83,7 +83,8 @@ public class ForcefieldRenderer extends MalisisRenderer {
         // ar.setStartTime(tileEntity.getStartNanoTime());
         if (tileEntity.getMovement() == null) return;
 
-        AxisAlignedBB aabb = tileEntity.getMovement().getBoundingBox(tileEntity, false, BoundingBoxType.COLLISION);
+        AxisAlignedBB aabb = tileEntity.getMovement()
+            .getBoundingBox(tileEntity, false, BoundingBoxType.COLLISION);
         if (aabb == null) return;
 
         aabb.offset(-x, -y, -z);
@@ -119,7 +120,8 @@ public class ForcefieldRenderer extends MalisisRenderer {
         GL11.glMatrixMode(GL11.GL_TEXTURE);
         GL11.glLoadIdentity();
 
-        AxisAlignedBB aabb = tileEntity.getMultiBlock().getBounds();
+        AxisAlignedBB aabb = tileEntity.getMultiBlock()
+            .getBounds();
         double scaleX = 1, scaleY = 1;
         if (direction == ForgeDirection.UP) {
             scaleX = aabb.maxX - aabb.minX;

--- a/src/main/java/net/malisis/doors/door/renderer/RustyHatchRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/RustyHatchRenderer.java
@@ -142,10 +142,13 @@ public class RustyHatchRenderer extends MalisisRenderer {
         setup(hatch);
         setup(handle);
 
-        ar.setStartTime(tileEntity.getTimer().getStart());
+        ar.setStartTime(
+            tileEntity.getTimer()
+                .getStart());
 
         if (tileEntity.getMovement() != null) {
-            Animation[] anims = tileEntity.getMovement().getAnimations(tileEntity, model, rp);
+            Animation[] anims = tileEntity.getMovement()
+                .getAnimations(tileEntity, model, rp);
             ar.animate(anims);
         }
 
@@ -192,16 +195,18 @@ public class RustyHatchRenderer extends MalisisRenderer {
     @Override
     protected boolean isCurrentBlockDestroyProgress(DestroyBlockProgress dbp) {
         if (!(world.getTileEntity(
-                dbp.getPartialBlockX(),
-                dbp.getPartialBlockY(),
-                dbp.getPartialBlockZ()) instanceof RustyHatchTileEntity))
-            return false;
+            dbp.getPartialBlockX(),
+            dbp.getPartialBlockY(),
+            dbp.getPartialBlockZ()) instanceof RustyHatchTileEntity)) return false;
 
         MultiBlock mb = MultiBlock
-                .getMultiBlock(world, dbp.getPartialBlockX(), dbp.getPartialBlockY(), dbp.getPartialBlockZ());
-        return mb != null && mb.getX() == tileEntity.getMultiBlock().getX()
-                && mb.getY() == tileEntity.getMultiBlock().getY()
-                && mb.getZ() == tileEntity.getMultiBlock().getZ();
+            .getMultiBlock(world, dbp.getPartialBlockX(), dbp.getPartialBlockY(), dbp.getPartialBlockZ());
+        return mb != null && mb.getX() == tileEntity.getMultiBlock()
+            .getX()
+            && mb.getY() == tileEntity.getMultiBlock()
+                .getY()
+            && mb.getZ() == tileEntity.getMultiBlock()
+                .getZ();
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/door/renderer/SaloonDoorRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/SaloonDoorRenderer.java
@@ -37,14 +37,17 @@ public class SaloonDoorRenderer extends DoorRenderer {
     @Override
     protected void renderTileEntity() {
         enableBlending();
-        ar.setStartTime(tileEntity.getTimer().getStart());
+        ar.setStartTime(
+            tileEntity.getTimer()
+                .getStart());
 
         setup();
 
         if (tileEntity.isReversed()) model.rotate(180, 0, 1, 0, 0, 0, 0);
 
         if (tileEntity.getMovement() != null) {
-            Animation[] anims = tileEntity.getMovement().getAnimations(tileEntity, model, rp);
+            Animation[] anims = tileEntity.getMovement()
+                .getAnimations(tileEntity, model, rp);
             ar.animate(anims);
         }
 

--- a/src/main/java/net/malisis/doors/door/tileentity/BigDoorTileEntity.java
+++ b/src/main/java/net/malisis/doors/door/tileentity/BigDoorTileEntity.java
@@ -136,7 +136,7 @@ public class BigDoorTileEntity extends DoorTileEntity {
     @Override
     public AxisAlignedBB getRenderBoundingBox() {
         return ((BigDoor) getBlockType())
-                .getBoundingBox(getWorldObj(), xCoord, yCoord, zCoord, BoundingBoxType.RENDER)[0]
-                        .offset(xCoord, yCoord, zCoord);
+            .getBoundingBox(getWorldObj(), xCoord, yCoord, zCoord, BoundingBoxType.RENDER)[0]
+                .offset(xCoord, yCoord, zCoord);
     }
 }

--- a/src/main/java/net/malisis/doors/door/tileentity/DoorTileEntity.java
+++ b/src/main/java/net/malisis/doors/door/tileentity/DoorTileEntity.java
@@ -113,7 +113,7 @@ public class DoorTileEntity extends TileEntity {
 
     public boolean isPowered() {
         return getWorldObj().isBlockIndirectlyGettingPowered(xCoord, yCoord, zCoord)
-                || getWorldObj().isBlockIndirectlyGettingPowered(xCoord, yCoord + 1, zCoord);
+            || getWorldObj().isBlockIndirectlyGettingPowered(xCoord, yCoord + 1, zCoord);
     }
 
     public boolean isCentered() {
@@ -143,7 +143,7 @@ public class DoorTileEntity extends TileEntity {
 
     public void onBlockPlaced(Door door, ItemStack itemStack) {
         DoorDescriptor desc = itemStack.getTagCompound() != null ? new DoorDescriptor(itemStack.getTagCompound())
-                : door.getDescriptor();
+            : door.getDescriptor();
         setDescriptor(desc);
     }
 
@@ -197,7 +197,8 @@ public class DoorTileEntity extends TileEntity {
         if (worldObj.isRemote) return;
 
         String soundPath = null;
-        if (descriptor.getSound() != null) soundPath = descriptor.getSound().getSoundPath(state);
+        if (descriptor.getSound() != null) soundPath = descriptor.getSound()
+            .getSoundPath(state);
         if (soundPath != null) getWorldObj().playSoundEffect(xCoord, yCoord, zCoord, soundPath, 1F, 1F);
     }
 
@@ -318,7 +319,7 @@ public class DoorTileEntity extends TileEntity {
 
     @Override
     public boolean shouldRefresh(Block oldBlock, Block newBlock, int oldMeta, int newMeta, World world, int x, int y,
-            int z) {
+        int z) {
         return oldBlock != newBlock;
     }
 }

--- a/src/main/java/net/malisis/doors/door/tileentity/FenceGateTileEntity.java
+++ b/src/main/java/net/malisis/doors/door/tileentity/FenceGateTileEntity.java
@@ -77,9 +77,10 @@ public class FenceGateTileEntity extends DoorTileEntity {
         if (te != null && isMatchingDoubleDoor(te)) p = p.offset(dir);
 
         BlockState state1 = new BlockState(worldObj, p);
-        int color1 = state1.getBlock().colorMultiplier(worldObj, p.getX(), p.getY(), p.getZ());
-        if (state1.getBlock().isAir(worldObj, p.getX(), p.getY(), p.getZ()))
-            return Pair.of(new BlockState(worldObj, pos), -1);
+        int color1 = state1.getBlock()
+            .colorMultiplier(worldObj, p.getX(), p.getY(), p.getZ());
+        if (state1.getBlock()
+            .isAir(worldObj, p.getX(), p.getY(), p.getZ())) return Pair.of(new BlockState(worldObj, pos), -1);
 
         dir = dir.getOpposite();
         p = pos.offset(dir);
@@ -88,9 +89,10 @@ public class FenceGateTileEntity extends DoorTileEntity {
         if (te != null && isMatchingDoubleDoor(te)) p = p.offset(dir);
 
         BlockState state2 = new BlockState(worldObj, p);
-        int color2 = state2.getBlock().colorMultiplier(worldObj, p.getX(), p.getY(), p.getZ());
-        if (state1.getBlock().isAir(worldObj, p.getX(), p.getY(), p.getZ()))
-            return Pair.of(new BlockState(worldObj, pos), -1);
+        int color2 = state2.getBlock()
+            .colorMultiplier(worldObj, p.getX(), p.getY(), p.getZ());
+        if (state1.getBlock()
+            .isAir(worldObj, p.getX(), p.getY(), p.getZ())) return Pair.of(new BlockState(worldObj, pos), -1);
 
         if (state1.getBlock() != state2.getBlock() || state1.getMetadata() != state2.getMetadata() || color1 != color2)
             return Pair.of(new BlockState(worldObj, pos), -1);
@@ -100,7 +102,7 @@ public class FenceGateTileEntity extends DoorTileEntity {
 
     private boolean updateWall() {
         ForgeDirection dir = getDirection() == Door.DIR_NORTH || getDirection() == Door.DIR_SOUTH ? ForgeDirection.EAST
-                : ForgeDirection.NORTH;
+            : ForgeDirection.NORTH;
         BlockPos pos = new BlockPos(xCoord, yCoord, zCoord);
 
         BlockState state = new BlockState(worldObj, pos.offset(dir));
@@ -113,7 +115,8 @@ public class FenceGateTileEntity extends DoorTileEntity {
     public IIcon getCamoIcon() {
         if (camoState == null) return getBlockType().getIcon(0, 0);
 
-        return camoState.getBlock().getIcon(0, 0);
+        return camoState.getBlock()
+            .getIcon(0, 0);
     }
 
     /**
@@ -157,7 +160,7 @@ public class FenceGateTileEntity extends DoorTileEntity {
             return false;
 
         if ((getDirection() == Door.DIR_NORTH || getDirection() == Door.DIR_SOUTH)
-                != (te.getDirection() == Door.DIR_NORTH || te.getDirection() == Door.DIR_SOUTH)) // different direction
+            != (te.getDirection() == Door.DIR_NORTH || te.getDirection() == Door.DIR_SOUTH)) // different direction
             return false;
 
         if (getMovement() != te.getMovement()) // different movement type

--- a/src/main/java/net/malisis/doors/door/tileentity/ForcefieldTileEntity.java
+++ b/src/main/java/net/malisis/doors/door/tileentity/ForcefieldTileEntity.java
@@ -53,7 +53,8 @@ public class ForcefieldTileEntity extends DoorTileEntity implements MultiBlock.I
 
     @Override
     public int getDirection() {
-        return multiBlock.getDirection().ordinal();
+        return multiBlock.getDirection()
+            .ordinal();
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/entity/BlockMixerTileEntity.java
+++ b/src/main/java/net/malisis/doors/entity/BlockMixerTileEntity.java
@@ -50,7 +50,7 @@ public class BlockMixerTileEntity extends TileEntity implements IInventoryProvid
 
         if (outputItemStack != null) {
             if (!ItemStack.areItemStackTagsEqual(outputItemStack, expected)
-                    || outputItemStack.stackSize >= outputItemStack.getMaxStackSize()) {
+                || outputItemStack.stackSize >= outputItemStack.getMaxStackSize()) {
                 mixTimer = 0;
                 return;
             }

--- a/src/main/java/net/malisis/doors/entity/DoorFactoryTileEntity.java
+++ b/src/main/java/net/malisis/doors/entity/DoorFactoryTileEntity.java
@@ -72,8 +72,8 @@ public class DoorFactoryTileEntity extends TileEntity implements IInventoryProvi
         outputSlot.setOutputSlot();
 
         inventory = new MalisisInventory(
-                this,
-                new MalisisSlot[] { frameSlot, topMaterialSlot, bottomMaterialSlot, doorEditSlot, outputSlot });
+            this,
+            new MalisisSlot[] { frameSlot, topMaterialSlot, bottomMaterialSlot, doorEditSlot, outputSlot });
     }
 
     public boolean isCreate() {
@@ -150,8 +150,8 @@ public class DoorFactoryTileEntity extends TileEntity implements IInventoryProvi
             ItemStack output = outputSlot.getItemStack();
             if (expected == null) return;
 
-            if (output != null && (!ItemStack.areItemStackTagsEqual(output, expected)
-                    || output.stackSize >= output.getMaxStackSize()))
+            if (output != null
+                && (!ItemStack.areItemStackTagsEqual(output, expected) || output.stackSize >= output.getMaxStackSize()))
                 return;
 
             frameSlot.extract(1);

--- a/src/main/java/net/malisis/doors/entity/GarageDoorTileEntity.java
+++ b/src/main/java/net/malisis/doors/entity/GarageDoorTileEntity.java
@@ -61,11 +61,11 @@ public class GarageDoorTileEntity extends DoorTileEntity {
 
     public GarageDoorTileEntity getGarageDoor(ForgeDirection dir) {
         GarageDoorTileEntity te = TileEntityUtils.getTileEntity(
-                GarageDoorTileEntity.class,
-                getWorldObj(),
-                xCoord + dir.offsetX,
-                yCoord + dir.offsetY,
-                zCoord + dir.offsetZ);
+            GarageDoorTileEntity.class,
+            getWorldObj(),
+            xCoord + dir.offsetX,
+            yCoord + dir.offsetY,
+            zCoord + dir.offsetZ);
         if (te == null) return null;
         if (te.getDirection() != getDirection()) return null;
 
@@ -84,7 +84,7 @@ public class GarageDoorTileEntity extends DoorTileEntity {
         }
 
         GarageDoorTileEntity te = getGarageDoor(
-                GarageDoor.isEastOrWest(blockMetadata) ? ForgeDirection.NORTH : ForgeDirection.EAST);
+            GarageDoor.isEastOrWest(blockMetadata) ? ForgeDirection.NORTH : ForgeDirection.EAST);
         if (te != null) te.setPowered(powered);
         te = getGarageDoor(GarageDoor.isEastOrWest(blockMetadata) ? ForgeDirection.SOUTH : ForgeDirection.WEST);
         if (te != null) te.setPowered(powered);
@@ -105,11 +105,11 @@ public class GarageDoorTileEntity extends DoorTileEntity {
     public AxisAlignedBB getRenderBoundingBox() {
         Set<GarageDoorTileEntity> childDoors = getDoors();
         return AxisAlignedBB.getBoundingBox(
-                xCoord - childDoors.size(),
-                yCoord - childDoors.size(),
-                zCoord - childDoors.size(),
-                xCoord + childDoors.size() + 1,
-                yCoord + 1,
-                zCoord + childDoors.size() + 1);
+            xCoord - childDoors.size(),
+            yCoord - childDoors.size(),
+            zCoord - childDoors.size(),
+            xCoord + childDoors.size() + 1,
+            yCoord + 1,
+            zCoord + childDoors.size() + 1);
     }
 }

--- a/src/main/java/net/malisis/doors/entity/VanishingDiamondTileEntity.java
+++ b/src/main/java/net/malisis/doors/entity/VanishingDiamondTileEntity.java
@@ -68,8 +68,10 @@ public class VanishingDiamondTileEntity extends VanishingTileEntity implements I
 
         changedPowerStateTimer = 0;
         for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
-            directionStates.get(dir).resetPropagationState();
-            directionStates.get(dir).propagateState(changedPowerStateTimer);
+            directionStates.get(dir)
+                .resetPropagationState();
+            directionStates.get(dir)
+                .propagateState(changedPowerStateTimer);
         }
 
         return true;
@@ -83,15 +85,22 @@ public class VanishingDiamondTileEntity extends VanishingTileEntity implements I
     public void updateEntity() {
         changedPowerStateTimer++;
 
-        for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS)
-            directionStates.get(dir).propagateState(changedPowerStateTimer);
+        for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) directionStates.get(dir)
+            .propagateState(changedPowerStateTimer);
 
         super.updateEntity();
     }
 
     @Subscribe
     public void onSlotChanged(InventoryEvent.SlotChanged event) {
-        setBlock(event.getSlot().getItemStack(), null, 0, 0.5F, 0.5F, 0.5F);
+        setBlock(
+            event.getSlot()
+                .getItemStack(),
+            null,
+            0,
+            0.5F,
+            0.5F,
+            0.5F);
         worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
     }
 
@@ -104,7 +113,8 @@ public class VanishingDiamondTileEntity extends VanishingTileEntity implements I
         for (int i = 0; i < dirList.tagCount(); ++i) {
             NBTTagCompound tag = dirList.getCompoundTagAt(i);
             ForgeDirection dir = ForgeDirection.getOrientation(tag.getInteger("direction"));
-            directionStates.get(dir).readFromNBT(tag);
+            directionStates.get(dir)
+                .readFromNBT(tag);
         }
     }
 
@@ -114,8 +124,9 @@ public class VanishingDiamondTileEntity extends VanishingTileEntity implements I
         inventory.writeToNBT(nbt);
 
         NBTTagList dirList = new NBTTagList();
-        for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS)
-            dirList.appendTag(directionStates.get(dir).writeToNBT(new NBTTagCompound()));
+        for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) dirList.appendTag(
+            directionStates.get(dir)
+                .writeToNBT(new NBTTagCompound()));
 
         nbt.setTag("Directions", dirList);
     }
@@ -173,13 +184,13 @@ public class VanishingDiamondTileEntity extends VanishingTileEntity implements I
             if (!shouldPropagate || propagated || timer < delay) return false;
 
             Block block = worldObj
-                    .getBlock(xCoord + direction.offsetX, yCoord + direction.offsetY, zCoord + direction.offsetZ);
+                .getBlock(xCoord + direction.offsetX, yCoord + direction.offsetY, zCoord + direction.offsetZ);
             if (block instanceof VanishingBlock) ((VanishingBlock) block).setPowerState(
-                    worldObj,
-                    xCoord + direction.offsetX,
-                    yCoord + direction.offsetY,
-                    zCoord + direction.offsetZ,
-                    inversed ? !powered : powered);
+                worldObj,
+                xCoord + direction.offsetX,
+                yCoord + direction.offsetY,
+                zCoord + direction.offsetZ,
+                inversed ? !powered : powered);
             propagated = true;
 
             return false;

--- a/src/main/java/net/malisis/doors/entity/VanishingTileEntity.java
+++ b/src/main/java/net/malisis/doors/entity/VanishingTileEntity.java
@@ -52,7 +52,7 @@ public class VanishingTileEntity extends TileEntity {
     private final Random rand = new Random();
 
     private Block[] excludes = new Block[] { MalisisDoors.Blocks.vanishingBlock, Blocks.air, Blocks.ladder,
-            Blocks.stone_button, Blocks.wooden_button, Blocks.lever, Blocks.vine };
+        Blocks.stone_button, Blocks.wooden_button, Blocks.lever, Blocks.vine };
 
     public VanishingTileEntity() {
         this.frameType = VanishingBlock.typeWoodFrame;
@@ -111,11 +111,11 @@ public class VanishingTileEntity extends TileEntity {
         this.powered = powered;
         this.inTransition = true;
         worldObj.setBlockMetadataWithNotify(
-                xCoord,
-                yCoord,
-                zCoord,
-                getBlockMetadata() | VanishingBlock.flagInTransition,
-                2);
+            xCoord,
+            yCoord,
+            zCoord,
+            getBlockMetadata() | VanishingBlock.flagInTransition,
+            2);
 
         return true;
     }
@@ -129,22 +129,22 @@ public class VanishingTileEntity extends TileEntity {
                 vibrating = true;
                 vibratingTimer = 0;
                 worldObj.setBlockMetadataWithNotify(
-                        xCoord,
-                        yCoord,
-                        zCoord,
-                        getBlockMetadata() | VanishingBlock.flagInTransition,
-                        2);
+                    xCoord,
+                    yCoord,
+                    zCoord,
+                    getBlockMetadata() | VanishingBlock.flagInTransition,
+                    2);
             }
 
             if (vibrating && vibratingTimer++ >= maxVibratingTime) {
                 vibrating = false;
                 vibratingTimer = 0;
                 worldObj.setBlockMetadataWithNotify(
-                        xCoord,
-                        yCoord,
-                        zCoord,
-                        getBlockMetadata() & ~VanishingBlock.flagInTransition,
-                        2);
+                    xCoord,
+                    yCoord,
+                    zCoord,
+                    getBlockMetadata() & ~VanishingBlock.flagInTransition,
+                    2);
             }
 
         } else if (inTransition) {
@@ -158,11 +158,11 @@ public class VanishingTileEntity extends TileEntity {
                     inTransition = false;
                     worldObj.spawnParticle("smoke", xCoord + 0.5F, yCoord + 0.5F, zCoord + 0.5F, 0.0F, 0.0F, 0.0F);
                     worldObj.setBlockMetadataWithNotify(
-                            xCoord,
-                            yCoord,
-                            zCoord,
-                            getBlockMetadata() & ~VanishingBlock.flagInTransition,
-                            2);
+                        xCoord,
+                        yCoord,
+                        zCoord,
+                        getBlockMetadata() & ~VanishingBlock.flagInTransition,
+                        2);
                 }
             } else
             // shutting down => going visible
@@ -171,11 +171,11 @@ public class VanishingTileEntity extends TileEntity {
                 if (transitionTimer <= 0) {
                     inTransition = false;
                     worldObj.setBlockMetadataWithNotify(
-                            xCoord,
-                            yCoord,
-                            zCoord,
-                            getBlockMetadata() & ~VanishingBlock.flagInTransition,
-                            2);
+                        xCoord,
+                        yCoord,
+                        zCoord,
+                        getBlockMetadata() & ~VanishingBlock.flagInTransition,
+                        2);
                 }
             }
         }

--- a/src/main/java/net/malisis/doors/gui/BlockMixerGui.java
+++ b/src/main/java/net/malisis/doors/gui/BlockMixerGui.java
@@ -38,10 +38,11 @@ public class BlockMixerGui extends MalisisGui {
         UISlot outputSlot = new UISlot(this, tileEntity.output).setPosition(0, 20, Anchor.CENTER);
 
         progressBar = new UIProgressBar(this).setPosition(-30, 21, Anchor.CENTER);
-        progressBarReversed = new UIProgressBar(this).setPosition(30, 21, Anchor.CENTER).setReversed();
+        progressBarReversed = new UIProgressBar(this).setPosition(30, 21, Anchor.CENTER)
+            .setReversed();
 
         cbRender = new UICheckBox(this, "gui.block_mixer.simple_rendering").setPosition(0, 50, Anchor.CENTER)
-                .register(this);
+            .register(this);
         cbRender.setTooltip(new UITooltip(this, "gui.block_mixer.simple_rendering_tooltip"));
 
         UIPlayerInventory playerInv = new UIPlayerInventory(this, inventoryContainer.getPlayerInventory());

--- a/src/main/java/net/malisis/doors/gui/Digicode.java
+++ b/src/main/java/net/malisis/doors/gui/Digicode.java
@@ -78,16 +78,25 @@ public class Digicode extends UIContainer<Digicode> {
             int x = ((i - 1) % 3) * 17;
             int y = (i - 1) / 3 * (h + 2);
 
-            UIButton b = new UIButton(gui, "" + i).setSize(16, h).setPosition(x, oy + y);
+            UIButton b = new UIButton(gui, "" + i).setSize(16, h)
+                .setPosition(x, oy + y);
             b.setName("" + i);
 
             add(b);
         }
 
-        add(new UIButton(gui, "C").setSize(16, h).setPosition(0, oy + 3 * (h + 2)).setName("C"));
-        add(new UIButton(gui, "0").setSize(16, h).setPosition(17, oy + 3 * (h + 2)).setName("0"));
-        if (!StringUtils.isEmpty(expectedCode))
-            add(new UIButton(gui, "V").setSize(16, h).setPosition(34, oy + 3 * (h + 2)).setName("V"));
+        add(
+            new UIButton(gui, "C").setSize(16, h)
+                .setPosition(0, oy + 3 * (h + 2))
+                .setName("C"));
+        add(
+            new UIButton(gui, "0").setSize(16, h)
+                .setPosition(17, oy + 3 * (h + 2))
+                .setName("0"));
+        if (!StringUtils.isEmpty(expectedCode)) add(
+            new UIButton(gui, "V").setSize(16, h)
+                .setPosition(34, oy + 3 * (h + 2))
+                .setName("V"));
     }
 
     @Override
@@ -124,7 +133,7 @@ public class Digicode extends UIContainer<Digicode> {
         renderer.drawText(font, "888888", fro);
 
         String code = enteredCode.length() < 6 ? StringUtils.repeat(' ', 6 - enteredCode.length()) + enteredCode
-                : enteredCode;
+            : enteredCode;
 
         fro.color = 0x00CC00;
         fro.saveDefault();
@@ -133,7 +142,8 @@ public class Digicode extends UIContainer<Digicode> {
 
     @Subscribe
     public void onButtonClick(UIButton.ClickEvent event) {
-        switch (event.getComponent().getName()) {
+        switch (event.getComponent()
+            .getName()) {
             case "C":
                 setEnteredCode("");
                 break;
@@ -144,7 +154,9 @@ public class Digicode extends UIContainer<Digicode> {
                 }
                 break;
             default:
-                setEnteredCode(enteredCode + event.getComponent().getName());
+                setEnteredCode(
+                    enteredCode + event.getComponent()
+                        .getName());
         }
     }
 

--- a/src/main/java/net/malisis/doors/gui/DigicodeGui.java
+++ b/src/main/java/net/malisis/doors/gui/DigicodeGui.java
@@ -33,12 +33,14 @@ public class DigicodeGui extends MalisisGui {
 
     public DigicodeGui(DoorTileEntity te) {
         this.te = te;
-        expected = te.getDescriptor().getCode();
+        expected = te.getDescriptor()
+            .getCode();
     }
 
     @Override
     public void construct() {
-        digicode = new Digicode(this, expected).setAnchor(Anchor.MIDDLE | Anchor.CENTER).register(this);
+        digicode = new Digicode(this, expected).setAnchor(Anchor.MIDDLE | Anchor.CENTER)
+            .register(this);
 
         UIWindow window = new UIWindow(this, digicode.getWidth() + 20, digicode.getHeight() + 20);
         window.add(digicode);

--- a/src/main/java/net/malisis/doors/gui/DoorFactoryGui.java
+++ b/src/main/java/net/malisis/doors/gui/DoorFactoryGui.java
@@ -58,8 +58,8 @@ import com.google.common.eventbus.Subscribe;
 public class DoorFactoryGui extends MalisisGui {
 
     public static ResourceLocation tabIconsRl = new ResourceLocation(
-            MalisisDoors.modid,
-            "textures/gui/doorFactoryTabIcons.png");
+        MalisisDoors.modid,
+        "textures/gui/doorFactoryTabIcons.png");
     public static GuiTexture tabTexture = new GuiTexture(tabIconsRl, 128, 128);
     public static IIcon propIcon = tabTexture.getIcon(0, 0, 64, 64);
     public static IIcon matIcon = tabTexture.getIcon(64, 0, 64, 64);
@@ -99,11 +99,14 @@ public class DoorFactoryGui extends MalisisGui {
 
         int a = 16;
         UITab tabProp = new UITab(this, new UIImage(this, tabTexture, propIcon).setSize(a, a)).setName("tab_prop");
-        tabProp.setTooltip(new UITooltip(this, "gui.door_factory.tab_properties")).register(this);
+        tabProp.setTooltip(new UITooltip(this, "gui.door_factory.tab_properties"))
+            .register(this);
         UITab tabMat = new UITab(this, new UIImage(this, tabTexture, matIcon).setSize(a, a)).setName("tab_mat");
-        tabMat.setTooltip(new UITooltip(this, "gui.door_factory.tab_materials")).register(this);
+        tabMat.setTooltip(new UITooltip(this, "gui.door_factory.tab_materials"))
+            .register(this);
         UITab tabDc = new UITab(this, new UIImage(this, tabTexture, dcIcon).setSize(a, a)).setName("tab_dc");
-        tabDc.setTooltip(new UITooltip(this, "gui.door_factory.tab_digicode")).register(this);
+        tabDc.setTooltip(new UITooltip(this, "gui.door_factory.tab_digicode"))
+            .register(this);
 
         tabGroup.addTab(tabProp, propContainer);
         tabGroup.addTab(tabMat, matContainer);
@@ -112,8 +115,9 @@ public class DoorFactoryGui extends MalisisGui {
         tabGroup.setActiveTab(activeTab != null ? activeTab : "tab_prop");
         tabGroup.attachTo(window, false);
 
-        btnCreate = new UIButton(this, "gui.door_factory.create_door").setSize(80).setPosition(0, 98, Anchor.CENTER)
-                .register(this);
+        btnCreate = new UIButton(this, "gui.door_factory.create_door").setSize(80)
+            .setPosition(0, 98, Anchor.CENTER)
+            .register(this);
         UISlot outputSlot = new UISlot(this, tileEntity.outputSlot).setPosition(0, 120, Anchor.CENTER);
 
         UIPlayerInventory playerInv = new UIPlayerInventory(this, inventoryContainer.getPlayerInventory());
@@ -137,23 +141,37 @@ public class DoorFactoryGui extends MalisisGui {
         UIContainer propContainer = new UIContainer<>(this, UIComponent.INHERITED, 80).setPosition(0, 15);
 
         selDoorMovement = new UISelect<String>(
-                this,
-                100,
-                getSortedList(DoorRegistry.listMovements().keySet(), "door_movement."));
+            this,
+            100,
+            getSortedList(
+                DoorRegistry.listMovements()
+                    .keySet(),
+                "door_movement."));
         selDoorMovement.setPosition(0, 2, Anchor.RIGHT);
-        selDoorMovement.setLabelPattern("door_movement.%s").register(this);
+        selDoorMovement.setLabelPattern("door_movement.%s")
+            .register(this);
 
-        tfOpenTime = new UITextField(this, null).setSize(30, 0).setPosition(-5, 14, Anchor.RIGHT).register(this);
-        tfAutoCloseTime = new UITextField(this, null).setSize(30, 0).setPosition(-5, 26, Anchor.RIGHT).register(this);
-        cbRedstone = new UICheckBox(this).setPosition(-15, 38, Anchor.RIGHT).register(this);
-        cbDoubleDoor = new UICheckBox(this).setPosition(-15, 50, Anchor.RIGHT).register(this);
+        tfOpenTime = new UITextField(this, null).setSize(30, 0)
+            .setPosition(-5, 14, Anchor.RIGHT)
+            .register(this);
+        tfAutoCloseTime = new UITextField(this, null).setSize(30, 0)
+            .setPosition(-5, 26, Anchor.RIGHT)
+            .register(this);
+        cbRedstone = new UICheckBox(this).setPosition(-15, 38, Anchor.RIGHT)
+            .register(this);
+        cbDoubleDoor = new UICheckBox(this).setPosition(-15, 50, Anchor.RIGHT)
+            .register(this);
 
         selDoorSound = new UISelect<String>(
-                this,
-                100,
-                getSortedList(DoorRegistry.listSounds().keySet(), "gui.door_factory.door_sound."));
+            this,
+            100,
+            getSortedList(
+                DoorRegistry.listSounds()
+                    .keySet(),
+                "gui.door_factory.door_sound."));
         selDoorSound.setPosition(0, 62, Anchor.RIGHT);
-        selDoorSound.setLabelPattern("gui.door_factory.door_sound.%s").register(this);
+        selDoorSound.setLabelPattern("gui.door_factory.door_sound.%s")
+            .register(this);
 
         propContainer.add(new UILabel(this, "gui.door_factory.door_movement").setPosition(0, 4));
         propContainer.add(new UILabel(this, "gui.door_factory.door_open_time").setPosition(0, 16));
@@ -173,21 +191,24 @@ public class DoorFactoryGui extends MalisisGui {
     }
 
     private ImmutableList<String> getSortedList(Set<String> set, final String prefix) {
-        return FluentIterable.from(set).toSortedList(new Comparator<String>() {
+        return FluentIterable.from(set)
+            .toSortedList(new Comparator<String>() {
 
-            @Override
-            public int compare(String s1, String s2) {
-                return StatCollector.translateToLocal(prefix + s1)
+                @Override
+                public int compare(String s1, String s2) {
+                    return StatCollector.translateToLocal(prefix + s1)
                         .compareTo(StatCollector.translateToLocal(prefix + s2));
-            }
-        });
+                }
+            });
     }
 
     private UIContainer getMaterialsContainer() {
         UIContainer matContainer = new UIContainer<>(this, UIComponent.INHERITED, 80).setPosition(0, 15);
 
-        rbCreate = new UIRadioButton(this, "rbDoor", "gui.door_factory.rb_create").setPosition(30, 0).register(this);
-        rbEdit = new UIRadioButton(this, "rbDoor", "gui.door_factory.rb_edit").setPosition(100, 0).register(this);
+        rbCreate = new UIRadioButton(this, "rbDoor", "gui.door_factory.rb_create").setPosition(30, 0)
+            .register(this);
+        rbEdit = new UIRadioButton(this, "rbDoor", "gui.door_factory.rb_edit").setPosition(100, 0)
+            .register(this);
 
         matContainer.add(rbCreate);
         matContainer.add(rbEdit);
@@ -198,7 +219,7 @@ public class DoorFactoryGui extends MalisisGui {
         UISlot frameSlot = new UISlot(this, tileEntity.frameSlot).setPosition(-10, y, Anchor.RIGHT);
         UISlot topMaterialSlot = new UISlot(this, tileEntity.topMaterialSlot).setPosition(-10, y + 18, Anchor.RIGHT);
         UISlot bottomMaterialSlot = new UISlot(this, tileEntity.bottomMaterialSlot)
-                .setPosition(-10, y + 36, Anchor.RIGHT);
+            .setPosition(-10, y + 36, Anchor.RIGHT);
 
         contCreate.add(new UILabel(this, "gui.door_factory.frame_type").setPosition(0, y + 5));
         contCreate.add(new UILabel(this, "gui.door_factory.top_material").setPosition(0, y + 23));
@@ -223,7 +244,8 @@ public class DoorFactoryGui extends MalisisGui {
     private UIContainer getDigicodeContainer() {
         UIContainer dcContainer = new UIContainer<>(this, UIComponent.INHERITED, 80).setPosition(0, 15);
 
-        digicode = new Digicode(this).setAnchor(Anchor.CENTER).register(this);
+        digicode = new Digicode(this).setAnchor(Anchor.CENTER)
+            .register(this);
         dcContainer.add(digicode);
 
         return dcContainer;
@@ -308,7 +330,8 @@ public class DoorFactoryGui extends MalisisGui {
     @Subscribe
     public void onTabActivation(ActiveStateChange<UITab> event) {
         if (event.getState()) {
-            activeTab = event.getComponent().getName();
+            activeTab = event.getComponent()
+                .getName();
 
             if ("tab_dc".equals(activeTab)) registerKeyListener(digicode);
             else unregisterKeyListener(digicode);

--- a/src/main/java/net/malisis/doors/gui/VanishingDiamondGui.java
+++ b/src/main/java/net/malisis/doors/gui/VanishingDiamondGui.java
@@ -69,15 +69,21 @@ public class VanishingDiamondGui extends MalisisGui {
             DirectionState state = tileEntity.getDirectionState(dir);
             int y = i * 14 + 30;
             UICheckBox cb = new UICheckBox(this, dir.name());
-            cb.setPosition(2, y).setChecked(state.shouldPropagate).register(this);
+            cb.setPosition(2, y)
+                .setChecked(state.shouldPropagate)
+                .register(this);
             cb.attachData(Pair.of(dir, DataType.PROPAGATION));
 
-            UITextField textField = new UITextField(this, "" + state.delay).setSize(27, 0).setPosition(55, y)
-                    .setDisabled(!state.shouldPropagate).register(this);
+            UITextField textField = new UITextField(this, "" + state.delay).setSize(27, 0)
+                .setPosition(55, y)
+                .setDisabled(!state.shouldPropagate)
+                .register(this);
             textField.attachData(Pair.of(dir, DataType.DELAY));
 
-            UICheckBox invCb = new UICheckBox(this).setPosition(105, y).setDisabled(!state.shouldPropagate)
-                    .setChecked(state.inversed).register(this);
+            UICheckBox invCb = new UICheckBox(this).setPosition(105, y)
+                .setDisabled(!state.shouldPropagate)
+                .setChecked(state.inversed)
+                .register(this);
             invCb.attachData(Pair.of(dir, DataType.INVERSED));
 
             window.add(cb);
@@ -91,7 +97,9 @@ public class VanishingDiamondGui extends MalisisGui {
 
         UIContainer cont = new UIContainer<UIContainer>(this, 50, 60).setPosition(0, 40, Anchor.RIGHT);
 
-        duration = new UITextField(this, null).setSize(30, 0).setPosition(0, 10, Anchor.CENTER).register(this);
+        duration = new UITextField(this, null).setSize(30, 0)
+            .setPosition(0, 10, Anchor.CENTER)
+            .register(this);
         duration.attachData(Pair.of(null, DataType.DURATION));
         cont.add(new UILabel(this, "Duration").setPosition(0, 0, Anchor.CENTER));
         cont.add(duration);
@@ -113,7 +121,8 @@ public class VanishingDiamondGui extends MalisisGui {
 
     @Subscribe
     public void onConfigChanged(ComponentEvent.ValueChange event) {
-        Pair<ForgeDirection, DataType> data = (Pair<ForgeDirection, DataType>) event.getComponent().getData();
+        Pair<ForgeDirection, DataType> data = (Pair<ForgeDirection, DataType>) event.getComponent()
+            .getData();
         int time = event.getComponent() instanceof UITextField ? NumberUtils.toInt((String) event.getNewValue()) : 0;
         boolean checked = event.getComponent() instanceof UICheckBox ? (boolean) event.getNewValue() : false;
         VanishingDiamondFrameMessage.sendConfiguration(tileEntity, data.getLeft(), data.getRight(), time, checked);
@@ -128,7 +137,8 @@ public class VanishingDiamondGui extends MalisisGui {
             UITextField tf = (UITextField) configs.get(dir)[1];
             tf.setDisabled(!state.shouldPropagate);
             if (!tf.isFocused()) tf.setText("" + state.delay);
-            ((UICheckBox) configs.get(dir)[2]).setDisabled(!state.shouldPropagate).setChecked(state.inversed);
+            ((UICheckBox) configs.get(dir)[2]).setDisabled(!state.shouldPropagate)
+                .setChecked(state.inversed);
         }
     }
 }

--- a/src/main/java/net/malisis/doors/item/VanishingBlockItem.java
+++ b/src/main/java/net/malisis/doors/item/VanishingBlockItem.java
@@ -44,7 +44,7 @@ public class VanishingBlockItem extends ItemBlock {
 
     @Override
     public boolean placeBlockAt(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side,
-            float hitX, float hitY, float hitZ, int metadata) {
+        float hitX, float hitY, float hitZ, int metadata) {
         Block block = field_150939_a;
         if ((metadata & 3) == VanishingBlock.typeDiamondFrame) block = MalisisDoors.Blocks.vanishingDiamondBlock;
 

--- a/src/main/java/net/malisis/doors/network/DigicodeMessage.java
+++ b/src/main/java/net/malisis/doors/network/DigicodeMessage.java
@@ -44,12 +44,17 @@ public class DigicodeMessage implements IMessageHandler<DigicodeMessage.Packet, 
 
         te.openOrCloseDoor();
 
-        if (te.getDescriptor().getAutoCloseTime() > 0 && !te.isOpened()) world.scheduleBlockUpdate(
+        if (te.getDescriptor()
+            .getAutoCloseTime() > 0 && !te.isOpened())
+            world.scheduleBlockUpdate(
                 message.x,
                 message.y,
                 message.z,
                 world.getBlock(message.x, message.y, message.z),
-                te.getDescriptor().getAutoCloseTime() + te.getDescriptor().getOpeningTime());
+                te.getDescriptor()
+                    .getAutoCloseTime()
+                    + te.getDescriptor()
+                        .getOpeningTime());
 
         return null;
     }

--- a/src/main/java/net/malisis/doors/network/DoorFactoryMessage.java
+++ b/src/main/java/net/malisis/doors/network/DoorFactoryMessage.java
@@ -42,7 +42,7 @@ public class DoorFactoryMessage implements IMessageHandler<DoorFactoryMessage.Pa
     public IMessage onMessage(Packet message, MessageContext ctx) {
         World world = ctx.getServerHandler().playerEntity.worldObj;
         DoorFactoryTileEntity te = TileEntityUtils
-                .getTileEntity(DoorFactoryTileEntity.class, world, message.x, message.y, message.z);
+            .getTileEntity(DoorFactoryTileEntity.class, world, message.x, message.y, message.z);
         if (te == null) return null;
 
         if (message.type == Packet.TYPE_DOORINFOS) {

--- a/src/main/java/net/malisis/doors/network/VanishingDiamondFrameMessage.java
+++ b/src/main/java/net/malisis/doors/network/VanishingDiamondFrameMessage.java
@@ -48,7 +48,7 @@ public class VanishingDiamondFrameMessage implements IMessageHandler<VanishingDi
     public IMessage onMessage(Packet message, MessageContext ctx) {
         World world = ctx.getServerHandler().playerEntity.worldObj;
         VanishingDiamondTileEntity te = TileEntityUtils
-                .getTileEntity(VanishingDiamondTileEntity.class, world, message.x, message.y, message.z);
+            .getTileEntity(VanishingDiamondTileEntity.class, world, message.x, message.y, message.z);
         if (te == null) return null;
 
         switch (message.type) {
@@ -71,7 +71,7 @@ public class VanishingDiamondFrameMessage implements IMessageHandler<VanishingDi
     }
 
     public static void sendConfiguration(VanishingDiamondTileEntity te, ForgeDirection facing, DataType type, int time,
-            boolean checked) {
+        boolean checked) {
         Packet packet = new Packet(te.xCoord, te.yCoord, te.zCoord, type, facing, time, checked);
         MalisisDoors.network.sendToServer(packet);
     }

--- a/src/main/java/net/malisis/doors/renderer/GarageDoorRenderer.java
+++ b/src/main/java/net/malisis/doors/renderer/GarageDoorRenderer.java
@@ -97,7 +97,9 @@ public class GarageDoorRenderer extends MalisisRenderer {
     protected void renderTileEntity() {
         int t = GarageDoorTileEntity.maxOpenTime;
         // set the start timer
-        ar.setStartTime(tileEntity.getTimer().getStart());
+        ar.setStartTime(
+            tileEntity.getTimer()
+                .getStart());
 
         // create door list from childs + top
         childDoors.clear();
@@ -161,8 +163,7 @@ public class GarageDoorRenderer extends MalisisRenderer {
 
         for (GarageDoorTileEntity te : childDoors) {
             if (dbp.getPartialBlockX() == te.xCoord && dbp.getPartialBlockY() == te.yCoord
-                    && dbp.getPartialBlockZ() == te.zCoord)
-                return true;
+                && dbp.getPartialBlockZ() == te.zCoord) return true;
         }
         return false;
     }

--- a/src/main/java/net/malisis/doors/renderer/MixedBlockRenderer.java
+++ b/src/main/java/net/malisis/doors/renderer/MixedBlockRenderer.java
@@ -56,9 +56,11 @@ public class MixedBlockRenderer extends MalisisRenderer {
             Shape s1 = new Cube();
             s0.enableMergedVertexes();
             s1.enableMergedVertexes();
-            shapes[0][dir.ordinal()] = s0.removeFace(s0.getFace(Face.nameFromDirection(dir))).storeState();
-            shapes[1][dir.ordinal()] = s1.shrink(dir, 0.999F).removeFace(s1.getFace(Face.nameFromDirection(dir)))
-                    .storeState();
+            shapes[0][dir.ordinal()] = s0.removeFace(s0.getFace(Face.nameFromDirection(dir)))
+                .storeState();
+            shapes[1][dir.ordinal()] = s1.shrink(dir, 0.999F)
+                .removeFace(s1.getFace(Face.nameFromDirection(dir)))
+                .storeState();
         }
 
         rp = new RenderParameters();
@@ -70,11 +72,17 @@ public class MixedBlockRenderer extends MalisisRenderer {
     private boolean setup() {
         if (renderType == RenderType.ITEM_INVENTORY) {
             if (!itemStack.hasTagCompound()) return false;
-            block1 = Block.getBlockById(itemStack.getTagCompound().getInteger("block1"));
-            block2 = Block.getBlockById(itemStack.getTagCompound().getInteger("block2"));
+            block1 = Block.getBlockById(
+                itemStack.getTagCompound()
+                    .getInteger("block1"));
+            block2 = Block.getBlockById(
+                itemStack.getTagCompound()
+                    .getInteger("block2"));
 
-            metadata1 = itemStack.getTagCompound().getInteger("metadata1");
-            metadata2 = itemStack.getTagCompound().getInteger("metadata2");
+            metadata1 = itemStack.getTagCompound()
+                .getInteger("metadata1");
+            metadata2 = itemStack.getTagCompound()
+                .getInteger("metadata2");
 
             mixedBlockMetadata = 3;
         } else if (renderType == RenderType.ISBRH_WORLD) {
@@ -107,7 +115,7 @@ public class MixedBlockRenderer extends MalisisRenderer {
         }
 
         if (MalisisDoorsSettings.simpleMixedBlockRendering.get()
-                || !Minecraft.getMinecraft().gameSettings.fancyGraphics) {
+            || !Minecraft.getMinecraft().gameSettings.fancyGraphics) {
             renderSimple();
             return;
         }
@@ -120,7 +128,7 @@ public class MixedBlockRenderer extends MalisisRenderer {
 
     private void setColor() {
         int color = renderType == RenderType.ISBRH_WORLD ? block.colorMultiplier(world, x, y, z)
-                : block.getBlockColor();
+            : block.getBlockColor();
         rp.colorMultiplier.set(color);
         shape.setParameters("Top", rp, true);
         if (block instanceof BlockGrass) {
@@ -163,14 +171,17 @@ public class MixedBlockRenderer extends MalisisRenderer {
         set(b, m);
         setColor();
 
-        simpleShape.resetState().setSize(width, height, depth);
+        simpleShape.resetState()
+            .setSize(width, height, depth);
         drawShape(simpleShape, rp);
 
         b = reversed ? block1 : block2;
         m = reversed ? metadata1 : metadata2;
         set(b, m);
         setColor();
-        simpleShape.resetState().setSize(width, height, depth).translate(offsetX, offestY, offsetZ);
+        simpleShape.resetState()
+            .setSize(width, height, depth)
+            .translate(offsetX, offestY, offsetZ);
         drawShape(simpleShape, rp);
     }
 
@@ -209,11 +220,12 @@ public class MixedBlockRenderer extends MalisisRenderer {
         if (p.direction.get() == null) return true;
 
         boolean b = MalisisDoors.Blocks.mixedBlock.shouldSideBeRendered(
-                world,
-                x + p.direction.get().offsetX,
-                y + p.direction.get().offsetY,
-                z + p.direction.get().offsetZ,
-                p.direction.get().ordinal());
+            world,
+            x + p.direction.get().offsetX,
+            y + p.direction.get().offsetY,
+            z + p.direction.get().offsetZ,
+            p.direction.get()
+                .ordinal());
         return b;
     }
 }

--- a/src/main/java/net/malisis/doors/trapdoor/TrapDoorDescriptor.java
+++ b/src/main/java/net/malisis/doors/trapdoor/TrapDoorDescriptor.java
@@ -34,7 +34,10 @@ public class TrapDoorDescriptor extends DoorDescriptor {
     public DoorDescriptor register() {
         if (block == null) create();
 
-        GameRegistry.registerBlock(block, block.getUnlocalizedName().substring(5));
+        GameRegistry.registerBlock(
+            block,
+            block.getUnlocalizedName()
+                .substring(5));
         if (recipe != null) GameRegistry.addRecipe(new ItemStack(block, numCrafted), recipe);
 
         return this;

--- a/src/main/java/net/malisis/doors/trapdoor/block/TrapDoor.java
+++ b/src/main/java/net/malisis/doors/trapdoor/block/TrapDoor.java
@@ -69,7 +69,7 @@ public class TrapDoor extends BlockTrapDoor implements ITileEntityProvider {
      */
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX,
-            float hitY, float hitZ) {
+        float hitY, float hitZ) {
         if (world.isRemote) return true;
 
         DoorTileEntity te = Door.getDoor(world, x, y, z);
@@ -77,7 +77,8 @@ public class TrapDoor extends BlockTrapDoor implements ITileEntityProvider {
 
         if (te.getDescriptor() == null) return true;
 
-        if (te.getDescriptor().requireRedstone()) return true;
+        if (te.getDescriptor()
+            .requireRedstone()) return true;
 
         te.openOrCloseDoor();
         return true;
@@ -93,12 +94,12 @@ public class TrapDoor extends BlockTrapDoor implements ITileEntityProvider {
     protected AxisAlignedBB setBlockBounds(AxisAlignedBB aabb) {
         if (aabb == null) return null;
         setBlockBounds(
-                (float) aabb.minX,
-                (float) aabb.minY,
-                (float) aabb.minZ,
-                (float) aabb.maxX,
-                (float) aabb.maxY,
-                (float) aabb.maxZ);
+            (float) aabb.minX,
+            (float) aabb.minY,
+            (float) aabb.minZ,
+            (float) aabb.maxX,
+            (float) aabb.maxY,
+            (float) aabb.maxZ);
         return aabb;
     }
 
@@ -107,7 +108,9 @@ public class TrapDoor extends BlockTrapDoor implements ITileEntityProvider {
         DoorTileEntity te = Door.getDoor(world, x, y, z);
         if (te == null || te.isMoving() || te.getMovement() == null) return;
 
-        setBlockBounds(te.getMovement().getBoundingBox(te, te.isTopBlock(x, y, z), BoundingBoxType.RAYTRACE));
+        setBlockBounds(
+            te.getMovement()
+                .getBoundingBox(te, te.isTopBlock(x, y, z), BoundingBoxType.RAYTRACE));
     }
 
     @SideOnly(Side.CLIENT)
@@ -117,7 +120,8 @@ public class TrapDoor extends BlockTrapDoor implements ITileEntityProvider {
         if (te == null || te.isMoving() || te.getMovement() == null)
             return AxisAlignedBB.getBoundingBox(0, 0, 0, 0, 0, 0);
 
-        AxisAlignedBB aabb = te.getMovement().getBoundingBox(te, te.isTopBlock(x, y, z), BoundingBoxType.SELECTION);
+        AxisAlignedBB aabb = te.getMovement()
+            .getBoundingBox(te, te.isTopBlock(x, y, z), BoundingBoxType.SELECTION);
         if (aabb == null) return AxisAlignedBB.getBoundingBox(0, 0, 0, 0, 0, 0);
 
         return aabb.offset(x, y, z);
@@ -128,7 +132,8 @@ public class TrapDoor extends BlockTrapDoor implements ITileEntityProvider {
         DoorTileEntity te = Door.getDoor(world, x, y, z);
         if (te == null || te.isMoving() || te.getMovement() == null) return null;
 
-        AxisAlignedBB aabb = te.getMovement().getBoundingBox(te, te.isTopBlock(x, y, z), BoundingBoxType.COLLISION);
+        AxisAlignedBB aabb = te.getMovement()
+            .getBoundingBox(te, te.isTopBlock(x, y, z), BoundingBoxType.COLLISION);
         if (aabb == null) return null;
         return setBlockBounds(aabb.offset(x, y, z));
     }

--- a/src/main/java/net/malisis/doors/trapdoor/movement/SlidingTrapDoorMovement.java
+++ b/src/main/java/net/malisis/doors/trapdoor/movement/SlidingTrapDoorMovement.java
@@ -66,7 +66,9 @@ public class SlidingTrapDoorMovement implements IDoorMovement {
     private Transformation getTransformation(DoorTileEntity tileEntity) {
         Translation translation = new Translation(0, 0, 0, 0, 0, 1 - Door.DOOR_WIDTH);
         translation.reversed(tileEntity.getState() == DoorState.CLOSING || tileEntity.getState() == DoorState.CLOSED);
-        translation.forTicks(tileEntity.getDescriptor().getOpeningTime());
+        translation.forTicks(
+            tileEntity.getDescriptor()
+                .getOpeningTime());
         return translation;
     }
 

--- a/src/main/java/net/malisis/doors/trapdoor/movement/TrapDoorMovement.java
+++ b/src/main/java/net/malisis/doors/trapdoor/movement/TrapDoorMovement.java
@@ -67,8 +67,11 @@ public class TrapDoorMovement implements IDoorMovement {
             fromAngle = tmp;
         }
 
-        return new Rotation(fromAngle, toAngle).aroundAxis(1, 0, 0).offset(0, -f, f)
-                .forTicks(tileEntity.getDescriptor().getOpeningTime());
+        return new Rotation(fromAngle, toAngle).aroundAxis(1, 0, 0)
+            .offset(0, -f, f)
+            .forTicks(
+                tileEntity.getDescriptor()
+                    .getOpeningTime());
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/trapdoor/renderer/TrapDoorRenderer.java
+++ b/src/main/java/net/malisis/doors/trapdoor/renderer/TrapDoorRenderer.java
@@ -47,7 +47,8 @@ public class TrapDoorRenderer extends DoorRenderer {
         trapDoorModel.addShape("shape", s);
         trapDoorModel.storeState();
 
-        s.getFace(Face.nameFromDirection(ForgeDirection.UP)).getParameters().calculateAOColor.set(true);
+        s.getFace(Face.nameFromDirection(ForgeDirection.UP))
+            .getParameters().calculateAOColor.set(true);
 
         s = new Cube();
         s.setSize(1, Door.DOOR_WIDTH / 2, 1);
@@ -93,12 +94,15 @@ public class TrapDoorRenderer extends DoorRenderer {
 
     @Override
     protected void renderTileEntity() {
-        ar.setStartTime(tileEntity.getTimer().getStart());
+        ar.setStartTime(
+            tileEntity.getTimer()
+                .getStart());
 
         setup();
 
         if (tileEntity.getMovement() != null) {
-            Animation[] anims = tileEntity.getMovement().getAnimations(tileEntity, model, rp);
+            Animation[] anims = tileEntity.getMovement()
+                .getAnimations(tileEntity, model, rp);
             ar.animate(anims);
         }
 

--- a/src/main/java/net/malisis/javacompat/JavaCompatibility.java
+++ b/src/main/java/net/malisis/javacompat/JavaCompatibility.java
@@ -41,7 +41,8 @@ import cpw.mods.fml.relauncher.FMLLaunchHandler;
  */
 public final class JavaCompatibility implements Runnable, HyperlinkListener {
 
-    private final boolean isWindowsClient = SystemUtils.IS_OS_WINDOWS && FMLLaunchHandler.side().isClient();
+    private final boolean isWindowsClient = SystemUtils.IS_OS_WINDOWS && FMLLaunchHandler.side()
+        .isClient();
     private final Object mutex = new Object();
 
     public JavaCompatibility() {}
@@ -62,10 +63,10 @@ public final class JavaCompatibility implements Runnable, HyperlinkListener {
         logger.error(StringUtils.repeat('=', 80));
         logger.error("MalisisCore requires Java 7 to be installed.");
         logger.error(
-                "Please install the latest Java 7 appropriate for your System from https://java.com/download/"
-                        + (isWindowsClient ? " or use the latest launcher from https://minecraft.net/" : ""));
+            "Please install the latest Java 7 appropriate for your System from https://java.com/download/"
+                + (isWindowsClient ? " or use the latest launcher from https://minecraft.net/" : ""));
         logger.error(
-                "If Java 7 is already installed, please make sure the right Java version is for the current profile in the Minecraft launcher.");
+            "If Java 7 is already installed, please make sure the right Java version is for the current profile in the Minecraft launcher.");
         logger.error("Thank you. The game will exit now.");
         logger.error(StringUtils.repeat('=', 80));
         logger.error("");
@@ -142,27 +143,33 @@ public final class JavaCompatibility implements Runnable, HyperlinkListener {
     private String getHtml(Font font) {
         // create some css from the label's font
         StringBuilder style = new StringBuilder("font-family:" + font.getFamily() + ";").append("font-weight:")
-                .append(font.isBold() ? "bold" : "normal").append(";").append("font-size:").append(font.getSize())
-                .append("pt;");
+            .append(font.isBold() ? "bold" : "normal")
+            .append(";")
+            .append("font-size:")
+            .append(font.getSize())
+            .append("pt;");
 
         return "<html><body style=\"" + style
-                + "\">"
-                + "<strong>MalisisCore requires Java 7 to be used.</strong><br /><br />"
-                + "Please install the latest Java 7 appropriate for your system from <a href=\"https://java.com/download/\">java.com/download</a>"
-                + (isWindowsClient
-                        ? "or use the latest launcher from <a href=\"https://minecraft.net/\">minecraft.net</a>"
-                        : "")
-                + "<br /><br />"
-                + "If Java 7 is already installed, please make sure the right Java version is used for the current profile in the Minecraft launcher.<br /><br />"
-                + "The game will exit now."
-                + "</body></html>";
+            + "\">"
+            + "<strong>MalisisCore requires Java 7 to be used.</strong><br /><br />"
+            + "Please install the latest Java 7 appropriate for your system from <a href=\"https://java.com/download/\">java.com/download</a>"
+            + (isWindowsClient ? "or use the latest launcher from <a href=\"https://minecraft.net/\">minecraft.net</a>"
+                : "")
+            + "<br /><br />"
+            + "If Java 7 is already installed, please make sure the right Java version is used for the current profile in the Minecraft launcher.<br /><br />"
+            + "The game will exit now."
+            + "</body></html>";
     }
 
     @Override
     public void hyperlinkUpdate(HyperlinkEvent e) {
-        if (e.getEventType().equals(HyperlinkEvent.EventType.ACTIVATED)) {
+        if (e.getEventType()
+            .equals(HyperlinkEvent.EventType.ACTIVATED)) {
             try {
-                Desktop.getDesktop().browse(e.getURL().toURI());
+                Desktop.getDesktop()
+                    .browse(
+                        e.getURL()
+                            .toURI());
             } catch (Exception ignored) {}
         }
     }
@@ -174,7 +181,8 @@ public final class JavaCompatibility implements Runnable, HyperlinkListener {
             method.setAccessible(true);
             method.invoke(null, -1);
         } catch (Throwable t) {
-            FMLCommonHandler.instance().exitJava(-1, false);
+            FMLCommonHandler.instance()
+                .exitJava(-1, false);
         }
     }
 


### PR DESCRIPTION
Also minor buildscript updates and SPOTLESS.

Diff between the old and new rendering over five minutes:
![image](https://github.com/GTNewHorizons/MalisisDoors/assets/75745146/8ca8d3c8-5abb-40ea-990c-a54032f1b6b0)
This also causes rendering to be about 1.4% slower. IMO the tradeoff is worth it.