### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/malisisdoors/lang/en_US.lang
+++ b/src/main/resources/assets/malisisdoors/lang/en_US.lang
@@ -38,6 +38,7 @@ item.curtain_black.name=Black Curtain
 
 
 tile.player_sensor.name=Player Sensor
+tile.vanishing_block.name=Vanishing Frame
 tile.vanishing_block_wood.name=Wooden Vanishing Frame
 tile.vanishing_block_iron.name=Iron Vanishing Frame
 tile.vanishing_block_gold.name=Gold Vanishing Frame
@@ -55,7 +56,9 @@ tile.wood_sliding_door.name=Wooden Glass Door
 tile.iron_sliding_door.name=Iron Glass Door
 tile.rustyHatch.name=Rusty Hatch
 tile.carriage_door.name=Carriage Door
+tile.carriage_door_collisionHelper.name=Carriage Door Collision Helper
 tile.medieval_door.name=Medieval Door
+tile.medieval_door_collisionHelper.name=Medieval Door Collision Helper
 tile.forcefieldDoor.name=Forcefield
 tile.rustyLadder.name=Rusty Ladder
 tile.door_spruce.name=Spruce Door


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.