### PR TITLE
Fixed configuration comments always beginning with "null"

### DIFF
--- a/src/main/java/net/malisis/core/configuration/setting/Setting.java
+++ b/src/main/java/net/malisis/core/configuration/setting/Setting.java
@@ -94,9 +94,13 @@ public abstract class Setting<T> {
      * @param config the config
      */
     public void load(Configuration config) {
-        String comment = null;
-        for (String c : comments) comment += StatCollector.translateToLocal(c) + " ";
-        property = config.get(category, key, writeValue(defaultValue), comment, type);
+        if (comments.length > 0) {
+            String comment = "";
+            for (String c : comments) comment += StatCollector.translateToLocal(c) + " ";
+            property = config.get(category, key, writeValue(defaultValue), comment, type);
+        } else {
+            property = config.get(category, key, writeValue(defaultValue), null, type);
+        }
         value = readValue(property.getString());
         if (value == null) throw new NullPointerException("readPropertyValue should not return null!");
     }


### PR DESCRIPTION
This PR slightly refactors MalisisCore `Setting#load` to avoid concatenating a string onto `null`. Instead, the length of the `comments` String array is checked. If it's above zero (there are comments for the given setting), build the comment normally by concatenating onto an empty string (***not*** `null`). Otherwise, pass `null` directly into the comment parameter in Forge's `Configuration#get` so that options with no comments won't have a blank `# ` above them (this is the same behavior as before).