### PR TITLE
Small thread-safety fix to prevent certain NullPointers

### DIFF
--- a/src/main/java/net/malisis/core/renderer/Parameter.java
+++ b/src/main/java/net/malisis/core/renderer/Parameter.java
@@ -105,10 +105,12 @@ public class Parameter<T> {
     }
 
     public T merged(Parameter<T> other) {
-        if (other.value != null) {
-            return other.value;
-        } else if (value != null) {
-            return value;
+        T val = this.value;
+        T otherVal = other.value;
+        if (otherVal != null) {
+            return otherVal;
+        } else if (val != null) {
+            return val;
         } else {
             return defaultValue;
         }


### PR DESCRIPTION
When the ISBRH for certain blocks is multi-threaded(a very small amount of obscure blocks use an ISBRH for some of the geometry, like the rusty ladder). Some race condition happens which means this method can return null.

Caching the fields into local variables makes the race condition not happen, so the method at least won't return a null value and cause a NullPointer crash.

This problem doesn't crop-up with Angelica at this point because we're not multi-threading the ISBRH, but the problem was found with FalseTweaks threaded rendering, so if we decide to multi-thread it's likely to occur for that as well.