### PR TITLE
Simplify font rendering

### DIFF
--- a/src/main/java/net/malisis/core/renderer/font/MalisisFont.java
+++ b/src/main/java/net/malisis/core/renderer/font/MalisisFont.java
@@ -57,7 +57,7 @@ import com.google.common.io.Files;
  */
 public class MalisisFont {
 
-    public static MalisisFont minecraftFont = new MinecraftFont();
+    public static MalisisFont minecraftFont = new VanillaFont();
 
     private static Pattern pattern = Pattern.compile("\\{(.*?)}");
 

--- a/src/main/java/net/malisis/core/renderer/font/VanillaFont.java
+++ b/src/main/java/net/malisis/core/renderer/font/VanillaFont.java
@@ -1,0 +1,65 @@
+package net.malisis.core.renderer.font;
+
+import java.awt.Font;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.util.ResourceLocation;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.gtnewhorizon.gtnhlib.util.font.FontRendering;
+import com.gtnewhorizon.gtnhlib.util.font.IFontParameters;
+
+/**
+ * A slightly simpler alternative for {@link MinecraftFont} that uses vanilla and GTNHLib methods.
+ * Incompatible with some settings in {@link FontRenderOptions}, but it doesn't look like the mod uses them anyway...
+ */
+public class VanillaFont extends MalisisFont {
+
+    private final FontRenderer fontRenderer;
+
+    public VanillaFont() {
+        super((Font) null);
+        this.textureRl = new ResourceLocation("textures/font/ascii.png");
+        fontRenderer = Minecraft.getMinecraft().fontRenderer;
+    }
+
+    @Override
+    public float getCharWidth(char c) {
+        IFontParameters fontParams = (IFontParameters) fontRenderer;
+        return fontParams.getCharWidthFine(c);
+    }
+
+    @Override
+    public float getCharWidth(char c, FontRenderOptions fro) {
+        return this.getCharWidth(c);
+    }
+
+    @Override
+    protected void drawString(String text, FontRenderOptions fro) {
+        fontRenderer.drawString(text, 0, 0, fro.color, fro.shadow);
+    }
+
+    @Override
+    public float getStringWidth(String str, FontRenderOptions fro, int start, int end) {
+        if (StringUtils.isEmpty(str)) return 0;
+
+        str = processString(str, null);
+        if (start == 0 && end == 0) {
+            return FontRendering.getStringWidth(str, fontRenderer);
+        }
+        String substr;
+        if (end == 0) {
+            substr = str.substring(start);
+        } else {
+            substr = str.substring(start, end);
+        }
+        return FontRendering.getStringWidth(substr, fontRenderer);
+    }
+
+    @Override
+    public float getStringHeight(FontRenderOptions fro) {
+        return fontRenderer.FONT_HEIGHT;
+    }
+}


### PR DESCRIPTION
Did you know that Malisis' Doors has its own set of font rendering classes and uses them to replace vanilla text rendering in its GUIs?
This PR creates one such class that uses vanilla and GTNHLib functionality as much as possible, mostly undoing the replacements. This breaks some functionality that the mod does not use (afaik), but fixes https://github.com/GTNewHorizons/Angelica/issues/1583

Tested in dev env by comparing before/after screenshots of the two GUIs that I am aware of. They looked identical, or nearly identical if Angelica was present; so this seems fine, but help in testing would be appreciated.