### PR TITLE
[Memory-opti:fix leak] Fix 10 world client leaks in renderers

### DIFF
--- a/src/main/java/net/malisis/core/client/gui/MalisisGui.java
+++ b/src/main/java/net/malisis/core/client/gui/MalisisGui.java
@@ -42,6 +42,7 @@ import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 
@@ -461,6 +462,13 @@ public abstract class MalisisGui extends GuiScreen {
      * TileEntity changes.
      */
     public void updateGui() {}
+
+    /**
+     * Returns the tile entity associated with this MalisisGui
+     */
+    public TileEntity getTileEntity() {
+        return null;
+    }
 
     public void animate(Animation animation) {
         animate(animation, 0);

--- a/src/main/java/net/malisis/core/client/gui/component/control/UIScrollBar.java
+++ b/src/main/java/net/malisis/core/client/gui/component/control/UIScrollBar.java
@@ -15,7 +15,6 @@ package net.malisis.core.client.gui.component.control;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.WeakHashMap;
 
 import net.malisis.core.client.gui.Anchor;
 import net.malisis.core.client.gui.GuiRenderer;
@@ -31,6 +30,7 @@ import net.minecraft.client.gui.GuiScreen;
 
 import org.lwjgl.input.Keyboard;
 
+import com.google.common.collect.MapMaker;
 import com.google.common.eventbus.Subscribe;
 
 /**
@@ -45,7 +45,9 @@ public class UIScrollBar extends UIComponent<UIScrollBar> implements IControlCom
         VERTICAL
     }
 
-    private static Map<UIComponent, Map<Type, UIScrollBar>> scrollbars = new WeakHashMap();
+    private static final Map<UIComponent<?>, Map<Type, UIScrollBar>> scrollbars = new MapMaker().weakKeys()
+        .weakValues()
+        .makeMap();
 
     /** The scroll thickness (Width for vertical, height for horizontal). */
     protected int scrollThickness = 10;

--- a/src/main/java/net/malisis/core/client/gui/component/interaction/UIRadioButton.java
+++ b/src/main/java/net/malisis/core/client/gui/component/interaction/UIRadioButton.java
@@ -14,8 +14,8 @@
 package net.malisis.core.client.gui.component.interaction;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import net.malisis.core.client.gui.GuiRenderer;
 import net.malisis.core.client.gui.MalisisGui;
@@ -31,13 +31,17 @@ import net.malisis.core.renderer.font.VanillaFont;
 import org.apache.commons.lang3.StringUtils;
 import org.lwjgl.opengl.GL11;
 
+import com.google.common.collect.MapMaker;
+
 /**
  * @author Ordinastie
  *
  */
 public class UIRadioButton extends UIComponent<UIRadioButton> implements IGuiText<UIRadioButton> {
 
-    private static HashMap<String, List<UIRadioButton>> radioButtons = new HashMap<>();
+    private static final Map<String, List<UIRadioButton>> radioButtons = new MapMaker().weakKeys()
+        .weakValues()
+        .makeMap();
 
     protected GuiIcon bgIcon;
     protected GuiIcon bgIconDisabled;

--- a/src/main/java/net/malisis/core/renderer/MalisisRenderer.java
+++ b/src/main/java/net/malisis/core/renderer/MalisisRenderer.java
@@ -71,7 +71,7 @@ public class MalisisRenderer extends TileEntitySpecialRenderer implements ISimpl
     /** Whether this {@link MalisisRenderer} initialized. (initialize() already called) */
     private boolean initialized = false;
     /** Id of this {@link MalisisRenderer}. */
-    protected int renderId = -1;
+    protected final int renderId;
     /** Current world reference (ISBRH/TESR/IRWL). */
     protected IBlockAccess world;
     /** RenderBlocks reference (ISBRH). */
@@ -230,6 +230,7 @@ public class MalisisRenderer extends TileEntitySpecialRenderer implements ISimpl
         prepare(RenderType.ISBRH_INVENTORY);
         render();
         clean();
+        renderBlocks = null;
     }
 
     /**
@@ -256,6 +257,8 @@ public class MalisisRenderer extends TileEntitySpecialRenderer implements ISimpl
         if (renderer.hasOverrideBlockTexture()) overrideTexture = renderer.overrideBlockTexture;
         render();
         clean();
+        tileEntity = null;
+        renderBlocks = null;
         return vertexDrawn;
     }
 
@@ -350,6 +353,7 @@ public class MalisisRenderer extends TileEntitySpecialRenderer implements ISimpl
                 }
             }
             clean();
+            tileEntity = null;
         }
     }
 

--- a/src/main/java/net/malisis/core/util/TileEntityUtils.java
+++ b/src/main/java/net/malisis/core/util/TileEntityUtils.java
@@ -14,6 +14,7 @@
 package net.malisis.core.util;
 
 import net.malisis.core.client.gui.MalisisGui;
+import net.minecraft.client.Minecraft;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 
@@ -26,14 +27,6 @@ import cpw.mods.fml.relauncher.SideOnly;
  * @author Ordinastie
  */
 public class TileEntityUtils {
-
-    /** Reference to the {@link TileEntity} currently being use for current opened {@link MalisisGui}. */
-    @SideOnly(Side.CLIENT)
-    private static TileEntity currentTileEntity;
-
-    /** Reference the to currently opened {@link MalisisGui}. */
-    @SideOnly(Side.CLIENT)
-    private static MalisisGui currenGui;
 
     /**
      * Gets the {@link TileEntity} of type <b>T</b> at the specified {@link BlockPos}.<br>
@@ -80,27 +73,16 @@ public class TileEntityUtils {
     }
 
     /**
-     * Links the {@link TileEntity} to the {@link MalisisGui}.<br>
-     * Allows the TileEntity to notify the MalisisGui of updates.
-     *
-     * @param te  the TileEntity
-     * @param gui the MalisisGui
-     */
-    @SideOnly(Side.CLIENT)
-    public static void linkTileEntityToGui(TileEntity te, MalisisGui gui) {
-        currentTileEntity = te;
-        currenGui = gui;
-        // currenGui.updateGui();
-    }
-
-    /**
      * Notifies the currently opened {@link MalisisGui} to update.
      *
      * @param te the {@link TileEntity} linked to the MalisisGui
      */
     @SideOnly(Side.CLIENT)
     public static void updateGui(TileEntity te) {
-        if (te != currentTileEntity) return;
-        currenGui.updateGui();
+        if (Minecraft.getMinecraft().currentScreen instanceof MalisisGui malisisGui) {
+            if (malisisGui.getTileEntity() != null && malisisGui.getTileEntity() == te) {
+                malisisGui.updateGui();
+            }
+        }
     }
 }

--- a/src/main/java/net/malisis/doors/door/renderer/BigDoorRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/BigDoorRenderer.java
@@ -76,6 +76,12 @@ public class BigDoorRenderer extends MalisisRenderer {
         } else if (renderType == RenderType.TESR_WORLD) renderTileEntity();
     }
 
+    @Override
+    public void reset() {
+        super.reset();
+        tileEntity = null;
+    }
+
     private void renderBlock() {
         BlockState state = tileEntity.getFrameState();
         if (!state.getBlock()

--- a/src/main/java/net/malisis/doors/door/renderer/CustomDoorRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/CustomDoorRenderer.java
@@ -141,6 +141,12 @@ public class CustomDoorRenderer extends DoorRenderer {
         this.tileEntity = (CustomDoorTileEntity) super.tileEntity;
     }
 
+    @Override
+    public void reset() {
+        super.reset();
+        tileEntity = null;
+    }
+
     private void setInfos(CustomDoorTileEntity te) {
         frameBlock = te.getFrame();
         topMaterialBlock = te.getTopMaterial();

--- a/src/main/java/net/malisis/doors/door/renderer/DoorRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/DoorRenderer.java
@@ -84,6 +84,12 @@ public class DoorRenderer extends MalisisRenderer {
         this.tileEntity = (DoorTileEntity) super.tileEntity;
     }
 
+    @Override
+    public void reset() {
+        super.reset();
+        tileEntity = null;
+    }
+
     protected void setup() {
         model.resetState();
 

--- a/src/main/java/net/malisis/doors/door/renderer/FenceGateRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/FenceGateRenderer.java
@@ -66,6 +66,12 @@ public class FenceGateRenderer extends DoorRenderer {
     }
 
     @Override
+    public void reset() {
+        super.reset();
+        tileEntity = null;
+    }
+
+    @Override
     protected void setup() {
         model.resetState();
         if (direction == Door.DIR_NORTH || direction == Door.DIR_SOUTH) model.rotate(90, 0, 1, 0, 0, 0, 0);

--- a/src/main/java/net/malisis/doors/door/renderer/ForcefieldRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/ForcefieldRenderer.java
@@ -112,6 +112,12 @@ public class ForcefieldRenderer extends MalisisRenderer {
         GL11.glDisable(GL11.GL_BLEND);
     }
 
+    @Override
+    public void reset() {
+        super.reset();
+        tileEntity = null;
+    }
+
     private void setTextureMatrix() {
         long elapsed = ar.getElapsedTime() / 50;
         int n = (int) (elapsed % 50);

--- a/src/main/java/net/malisis/doors/door/renderer/RustyHatchRenderer.java
+++ b/src/main/java/net/malisis/doors/door/renderer/RustyHatchRenderer.java
@@ -43,7 +43,7 @@ public class RustyHatchRenderer extends MalisisRenderer {
     private Shape hatch;
     private Shape handle;
     private Shape ladder;
-    private AnimationRenderer ar = new AnimationRenderer();
+    private final AnimationRenderer ar = new AnimationRenderer();
     private RustyHatchTileEntity tileEntity;
 
     private boolean topBlock;
@@ -189,6 +189,12 @@ public class RustyHatchRenderer extends MalisisRenderer {
         if (direction == ForgeDirection.SOUTH) s.rotate(-90, 0, 1, 0);
         else if (direction == ForgeDirection.NORTH) s.rotate(90, 0, 1, 0);
         else if (direction == ForgeDirection.WEST) s.rotate(180, 0, 1, 0);
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        tileEntity = null;
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/gui/DoorFactoryGui.java
+++ b/src/main/java/net/malisis/doors/gui/DoorFactoryGui.java
@@ -38,11 +38,11 @@ import net.malisis.core.client.gui.component.interaction.UITextField;
 import net.malisis.core.client.gui.event.ComponentEvent.ValueChange;
 import net.malisis.core.client.gui.event.component.StateChangeEvent.ActiveStateChange;
 import net.malisis.core.inventory.MalisisInventoryContainer;
-import net.malisis.core.util.TileEntityUtils;
 import net.malisis.doors.MalisisDoors;
 import net.malisis.doors.door.DoorRegistry;
 import net.malisis.doors.entity.DoorFactoryTileEntity;
 import net.malisis.doors.network.DoorFactoryMessage;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
@@ -84,7 +84,6 @@ public class DoorFactoryGui extends MalisisGui {
     public DoorFactoryGui(DoorFactoryTileEntity te, MalisisInventoryContainer container) {
         setInventoryContainer(container);
         tileEntity = te;
-        TileEntityUtils.linkTileEntityToGui(tileEntity, this);
     }
 
     @Override
@@ -249,6 +248,11 @@ public class DoorFactoryGui extends MalisisGui {
         dcContainer.add(digicode);
 
         return dcContainer;
+    }
+
+    @Override
+    public TileEntity getTileEntity() {
+        return this.tileEntity;
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/gui/VanishingDiamondGui.java
+++ b/src/main/java/net/malisis/doors/gui/VanishingDiamondGui.java
@@ -27,11 +27,11 @@ import net.malisis.core.client.gui.component.interaction.UICheckBox;
 import net.malisis.core.client.gui.component.interaction.UITextField;
 import net.malisis.core.client.gui.event.ComponentEvent;
 import net.malisis.core.inventory.MalisisInventoryContainer;
-import net.malisis.core.util.TileEntityUtils;
 import net.malisis.doors.entity.VanishingDiamondTileEntity;
 import net.malisis.doors.entity.VanishingDiamondTileEntity.DirectionState;
 import net.malisis.doors.network.VanishingDiamondFrameMessage;
 import net.malisis.doors.network.VanishingDiamondFrameMessage.DataType;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.apache.commons.lang3.math.NumberUtils;
@@ -115,8 +115,6 @@ public class VanishingDiamondGui extends MalisisGui {
         window.add(playerInv);
 
         addToScreen(window);
-
-        TileEntityUtils.linkTileEntityToGui(tileEntity, this);
     }
 
     @Subscribe
@@ -126,6 +124,11 @@ public class VanishingDiamondGui extends MalisisGui {
         int time = event.getComponent() instanceof UITextField ? NumberUtils.toInt((String) event.getNewValue()) : 0;
         boolean checked = event.getComponent() instanceof UICheckBox ? (boolean) event.getNewValue() : false;
         VanishingDiamondFrameMessage.sendConfiguration(tileEntity, data.getLeft(), data.getRight(), time, checked);
+    }
+
+    @Override
+    public TileEntity getTileEntity() {
+        return this.tileEntity;
     }
 
     @Override

--- a/src/main/java/net/malisis/doors/renderer/RustyLadderRenderer.java
+++ b/src/main/java/net/malisis/doors/renderer/RustyLadderRenderer.java
@@ -74,6 +74,5 @@ public class RustyLadderRenderer extends MalisisRenderer {
         ladder.translate(-1, 0, 0);
 
         drawShape(ladder, rp);
-        return;
     }
 }


### PR DESCRIPTION
Pretty much every renderer had a memory leak

<img width="518" height="91" alt="image" src="https://github.com/user-attachments/assets/41cc65aa-7d78-4016-bb3a-62c5d996a3e5" />
<img width="473" height="115" alt="image" src="https://github.com/user-attachments/assets/da60d674-3340-41c6-93e3-2abbad85554f" />
<img width="395" height="81" alt="image" src="https://github.com/user-attachments/assets/8e191cb4-bc1d-4cc2-97aa-da7111414003" />
<img width="568" height="205" alt="image" src="https://github.com/user-attachments/assets/59bcafd0-011b-49e2-ac87-cc827b5058f6" />
<img width="648" height="228" alt="image" src="https://github.com/user-attachments/assets/4104dfbf-88ec-42fd-a805-2314f8e71546" />
