### PR TITLE
fix doors and trapdoors not using the block's open state when creating the TileEntity

### DIFF
--- a/src/main/java/net/malisis/doors/door/block/Door.java
+++ b/src/main/java/net/malisis/doors/door/block/Door.java
@@ -365,6 +365,8 @@ public class Door extends BlockDoor implements ITileEntityProvider, IBoundingBox
         } catch (InstantiationException | IllegalAccessException e) {
             te = new DoorTileEntity();
         }
+        boolean open = (metadata & FLAG_OPENED) != 0;
+        te.setDoorState(open ? DoorState.OPENED : DoorState.CLOSED);
         te.setDescriptor(descriptor);
         return te;
     }

--- a/src/main/java/net/malisis/doors/trapdoor/block/TrapDoor.java
+++ b/src/main/java/net/malisis/doors/trapdoor/block/TrapDoor.java
@@ -14,6 +14,7 @@
 package net.malisis.doors.trapdoor.block;
 
 import net.malisis.core.block.BoundingBoxType;
+import net.malisis.doors.door.DoorState;
 import net.malisis.doors.door.block.Door;
 import net.malisis.doors.door.tileentity.DoorTileEntity;
 import net.malisis.doors.trapdoor.TrapDoorDescriptor;
@@ -138,6 +139,8 @@ public class TrapDoor extends BlockTrapDoor implements ITileEntityProvider {
     @Override
     public TileEntity createNewTileEntity(World world, int metadata) {
         TrapDoorTileEntity te = new TrapDoorTileEntity();
+        boolean open = (metadata & Door.FLAG_OPENED) != 0;
+        te.setDoorState(open ? DoorState.OPENED : DoorState.CLOSED);
         te.setDescriptor(descriptor);
         return te;
     }


### PR DESCRIPTION
Sets the open/close value of the TileEntity when its created based on the metadata of the door

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24401