### PR TITLE
Make doors remember previous manual actions

### DIFF
--- a/src/main/java/net/malisis/doors/door/tileentity/DoorTileEntity.java
+++ b/src/main/java/net/malisis/doors/door/tileentity/DoorTileEntity.java
@@ -40,6 +40,12 @@ public class DoorTileEntity extends TileEntity {
     protected int lastMetadata = -1;
     protected Timer timer = new Timer();
     protected DoorState state = DoorState.CLOSED;
+
+    /**
+     * This replicates the 'powered' block-state of modern Minecraft
+     */
+    protected boolean powered;
+
     protected boolean moving;
     protected boolean centered = false;
 
@@ -250,9 +256,13 @@ public class DoorTileEntity extends TileEntity {
     }
 
     /**
-     * Change the state of this DoorTileEntity based on powered
+     * Change the state of this DoorTileEntity based on powered. This only updates the state of the door if the new
+     * powered state differs from the old powered state.
      */
     public void setPowered(boolean powered) {
+        if (this.powered == powered) return;
+        this.powered = powered;
+
         if (isOpened() == powered && !isMoving()) return;
 
         DoorTileEntity te = getDoubleDoor();
@@ -280,6 +290,7 @@ public class DoorTileEntity extends TileEntity {
         descriptor = new DoorDescriptor(nbt);
         setDoorState(DoorState.values()[nbt.getInteger("state")]);
         setCentered(nbt.getBoolean("centered"));
+        powered = nbt.getBoolean("powered");
     }
 
     @Override
@@ -288,6 +299,7 @@ public class DoorTileEntity extends TileEntity {
         if (descriptor != null) descriptor.writeNBT(nbt);
         nbt.setInteger("state", state.ordinal());
         nbt.setBoolean("centered", centered);
+        nbt.setBoolean("powered", powered);
     }
 
     @Override


### PR DESCRIPTION
## Summary
This PR adds a 'powered' variable to each door that tracks the previous power state. This makes manual open, and close actions persist through updates to the redstone-power state that don't explicitly undo said manual action. This replicates vanilla behaviour in modern Minecraft.

This (partially) addresses [#21237](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21237)

## Images

(For context, the EBF can provide redstone power and block-updates on world-load. This is the arrangement that caused me to look into this in the first place. This would occur when any redstone-capable block updates.)

Before reloading the world:
<img width="854" height="480" alt="2026-08-13_00 21 45" src="https://github.com/user-attachments/assets/b503d44e-72da-4c4d-99d6-861f219547c4" />

After reloading without the change:
<img width="854" height="480" alt="2026-08-13_00 25 23" src="https://github.com/user-attachments/assets/a9dffcde-626c-4171-8f37-e5ebfe915ad7" />

After reloading with the change:
<img width="854" height="480" alt="2026-08-13_00 22 00" src="https://github.com/user-attachments/assets/4ab8b063-d839-4ff6-b5a0-c35f6369526c" />

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
